### PR TITLE
Add missing whitespaces

### DIFF
--- a/web/src/components/pages/add.jsx
+++ b/web/src/components/pages/add.jsx
@@ -312,8 +312,8 @@ const ConfirmForm = (props) => (
     )}
     <p><b>{`${props.readyCount} sentences ready for submission!`}</b></p>
     <p>
-      By submitting these sentences you grant a 
-      <a href="https://en.wikipedia.org/wiki/Public_domain" target="_blank">Public Domain License</a> 
+      By submitting these sentences you grant a {}
+      <a href="https://en.wikipedia.org/wiki/Public_domain" target="_blank">Public Domain License</a> {}
       for self-written sentences, or declare that sentences from a third-party are under Public Domain License
       and can be used.
     </p>

--- a/web/src/components/pages/add.jsx
+++ b/web/src/components/pages/add.jsx
@@ -312,8 +312,8 @@ const ConfirmForm = (props) => (
     )}
     <p><b>{`${props.readyCount} sentences ready for submission!`}</b></p>
     <p>
-      By submitting these sentences you grant a
-      <a href="https://en.wikipedia.org/wiki/Public_domain" target="_blank">Public Domain License</a>
+      By submitting these sentences you grant a 
+      <a href="https://en.wikipedia.org/wiki/Public_domain" target="_blank">Public Domain License</a> 
       for self-written sentences, or declare that sentences from a third-party are under Public Domain License
       and can be used.
     </p>


### PR DESCRIPTION
This should fix this issue.

![screenshot from 2019-01-08 14-14-55](https://user-images.githubusercontent.com/91113/50832878-d47fcc00-134f-11e9-8836-afaee9af9809.png)

I havn't tested it.

Also, it's strange that other lines in that paragraph add whitespaces automatically. Maybe this is a general issue with the templating system. Feel free to suggest a better solution.