### PR TITLE
feature: Add spinner to validating/uploading hints (solves issue #95)

### DIFF
--- a/web/css/root.css
+++ b/web/css/root.css
@@ -208,3 +208,15 @@ form button {
   align-items: center;
   font-size: 0.7rem;
 }
+
+.divCenter {
+  text-align: center;
+  margin: 1em 0;
+}
+
+.loadingText {
+  display: inline-block;
+  font-size: 80%;
+  font-weight: 800;
+  width: 40%;
+}

--- a/web/css/spinner-button.css
+++ b/web/css/spinner-button.css
@@ -1,0 +1,39 @@
+.spinnerButton {
+  display: inline-block;
+  background: black;
+  color: white;
+  position: relative;
+  transition: padding-right .3s ease;
+  font-weight: 700;
+}
+
+.spinnerButton.spinning {
+  padding-right: 40px;
+  cursor: not-allowed;
+}
+
+.spinnerButton.spinning:before {
+  content: "";
+  width: 0px;
+  height: 0px;
+  border-radius: 50%;
+  right: 6px;
+  top: 50%;
+  position: absolute;
+  border-right: 3px solid #2795ae;
+  animation: rotate360 .5s infinite linear, exist .1s forwards ease ;
+}
+
+@keyframes rotate360 {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes exist {
+  100% {
+    width: 15px;
+    height: 15px;
+    margin: -8px 5px 0 0;
+  }
+}

--- a/web/src/components/confirm-form.jsx
+++ b/web/src/components/confirm-form.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import ReviewLink from './review-link';
+import SpinnerButton from './spinner-button';
 
 function mapStateToProps(state) {
   return {
@@ -71,14 +72,22 @@ class ConfirmForm extends React.Component {
         )}
 
         <section id="confirm-buttons">
-          { pendingSentences && (
-            <p>
-              <strong>Sentences are being uploaded. This can take several minutes depending on the number of sentences added.
-              Please don't close this website.</strong>
-            </p>
-          )}
-          <button type="submit" disabled={pendingSentences || readyCount === 0}>Confirm</button>
+
+          { pendingSentences ? 
+            <SpinnerButton></SpinnerButton> :
+            <button type="submit" disabled={readyCount === 0}>Confirm</button>
+          }
+
           <button onClick={this.onCancel}>Cancel</button>
+
+          { pendingSentences && (
+            <div>
+              <p className="loadingText">Sentences are being uploaded. This can take several minutes depending on the number of sentences added.
+            Please don't close this website.
+              </p>
+            </div>
+          )}
+          
         </section>
 
         {filtered.length > 0 && (

--- a/web/src/components/review-form.jsx
+++ b/web/src/components/review-form.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import '../../css/review-form.css';
+import SpinnerButton from './spinner-button';
 
 const PAGE_SIZE = 3;
 const DEFAULT_STATE = {
@@ -128,13 +129,20 @@ export default class ReviewForm extends React.Component {
           </section>
         )) }
 
-        { this.state.pendingSentences && (
-          <p>
-            <strong>Reviews are being uploaded. This can take several minutes depending on the number of sentences added.
-            Please don't close this website.</strong>
-          </p>
-        )}
-        <button type="submit" disabled={this.state.pendingSentences}>Finish Review</button>
+        <section id="confirm-buttons" className="divCenter">
+          { this.state.pendingSentences ?
+            <SpinnerButton></SpinnerButton> :
+            <button type="submit">Finish Review</button>
+          }
+
+          { this.state.pendingSentences && (
+            <div>
+              <p className="loadingText">Reviews are being uploaded. This can take several minutes depending on the number of sentences added.
+                Please don't close this website.</p>
+            </div>
+          )}
+        </section>
+
       </form>
     );
   }

--- a/web/src/components/spinner-button.jsx
+++ b/web/src/components/spinner-button.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import '../../css/spinner-button.css';
+
+
+const SpinnerButton = () => {
+  return (
+    <button className="spinnerButton spinning" disabled="disabled">Submitting...</button>
+  );
+};
+
+export default SpinnerButton;

--- a/web/src/components/submit-form.jsx
+++ b/web/src/components/submit-form.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import LanguageSelector from './language-selector';
+import SpinnerButton from './spinner-button';
+
 
 function mapStateToProps(state) {
   return {
@@ -14,7 +16,6 @@ function mapStateToProps(state) {
 class SubmitForm extends React.Component {
   constructor(props) {
     super(props);
-
     this.onSubmit = this.props.onSubmit.bind(this);
   }
 
@@ -74,14 +75,19 @@ class SubmitForm extends React.Component {
           </label>
         </section>
 
-        <section>
+        <section id="confirm-buttons" className="divCenter">
+          { parsingSentences ?
+            <SpinnerButton></SpinnerButton> :
+            <button>Submit</button>
+          } 
+
           { parsingSentences && (
-            <p>
-              <strong>Sentences are being validated. This can take a few seconds depending on the number of sentences added.</strong>
-            </p>
+            <div>
+              <p className="loadingText">Sentences are being validated. This can take a few seconds depending on the number of sentences added.</p>
+            </div> 
           )}
-          <button disabled={parsingSentences}>Submit</button>
         </section>
+
       </form>
     );
   }


### PR DESCRIPTION
This solves issue #95. 
I created a separate and reusable component for the CSS spinner button, separate CSS from root in a different file and imported the component in each view to use it.

The changed views are:

* submit_form.jsx: Add (sidebar) -> initial form there
* confirm_form.jsx: Add (sidebar) -> view after initial submission ("confirm")
* review_form.jsx: Review (sidebar) -> this form when submitting