### PR TITLE
feat: add gsw (Swiss German) language

### DIFF
--- a/shared/languages.js
+++ b/shared/languages.js
@@ -49,6 +49,11 @@ const ADDITIONAL_LANGUAGES = [
     nativeName: 'Irish',
   },
   {
+    code: 'gsw',
+    name: 'Swiss German',
+    nativeName: 'Schwizerdütsch',
+  },
+  {
     code: 'hsb',
     name: 'Upper Sorbian',
     nativeName: 'Hornjoserbšćina',


### PR DESCRIPTION
I'm not sure if this is the right place to start. I'd like to contribute Swiss German sentences. Note that there are no standardized grammar rules. Swiss German is mostly used in spoken context (instant messaging being the most notable exception) and can vary a lot depending on the region. In written form, Swiss people usually use standard German (de, de-CH).