### PR TITLE
Adding italian validator

### DIFF
--- a/shared/validation/index.js
+++ b/shared/validation/index.js
@@ -1,9 +1,11 @@
 import tokenizeWords from 'talisman/tokenizers/words';
 
 import * as en from './languages/en';
+import * as it from './languages/it';
 
 const VALIDATORS = {
   en,
+  it,
 };
 
 const DEFAULT_VALIDATOR_LANGUAGE = 'en';

--- a/shared/validation/languages/it.js
+++ b/shared/validation/languages/it.js
@@ -13,12 +13,12 @@ const MAX_WORDS = 17;
 // Italian: Simboli non permessi, aggiungere anche qui sotto oltre che nella regex:
 // “ ” ‘ ’ ( ) É 
 //doppio " " e più di un "." nella stessa frase.
-const SYMBOL_REGEX = /[“”‘’\(\)É(\..*\.)(  )]/       //  original:   /[<>\+\*\\#@\^\[\]\(\)\/]/;
+const SYMBOL_REGEX = /[“”‘’\(\)(\..*\.)(  )]/       //  original:   /[<>\+\*\\#@\^\[\]\(\)\/]/;
 // Any words consisting of uppercase letters or uppercase letters with a period
 // inbetween are considered abbreviations or acronyms.
 // This currently also matches fooBAR but we most probably don't want that either
 // as users wouldn't know how to pronounce the uppercase letters.
-const ABBREVIATION_REGEX = /[A-Z]{2,}|[A-Z]+\.*[A-Z]+/;
+const ABBREVIATION_REGEX = /[A-Z][a-z]{2,}|[A-Z][a-z]+\.*[A-Z][a-z]+/;
 
 
 export function getMaxLength() {

--- a/shared/validation/languages/it.js
+++ b/shared/validation/languages/it.js
@@ -13,7 +13,7 @@ const MAX_WORDS = 17;
 // Italian: Simboli non permessi, aggiungere anche qui sotto oltre che nella regex:
 // “ ” ‘ ’ ( ) É 
 //doppio " " e più di un "." nella stessa frase.
-const SYMBOL_REGEX = /[“”‘’\(\)(\..*\.)(  )]/       //  original:   /[<>\+\*\\#@\^\[\]\(\)\/]/;
+const SYMBOL_REGEX = /[“”‘’\(\)É]| {2,}|\..*\./       //  original:   /[<>\+\*\\#@\^\[\]\(\)\/]/;
 // Any words consisting of uppercase letters or uppercase letters with a period
 // inbetween are considered abbreviations or acronyms.
 // This currently also matches fooBAR but we most probably don't want that either

--- a/shared/validation/languages/it.js
+++ b/shared/validation/languages/it.js
@@ -1,0 +1,46 @@
+// Minimum of words that qualify as a sentence.
+const MIN_WORDS = 1;
+
+// Maximum of words allowed per sentence to keep recordings in a manageable duration. 
+// Italian: finché non abbiamo il controllo sui caratteri, o quello che tiene conto della presenza di numeri, metto 17 parole che dovrebbero essere salvo rarissimi casi sempre entro il limite di 125 caratteri. 
+const MAX_WORDS = 17;
+
+// Numbers that are not allowed in a sentence depending on the language. For
+// Italian: tutti i numeri sono consentiti ma se e quando avremo la possibilità di fare regole personalizzate metteremo una condizione ulteriore sulla lunghezza se vi sono dei numeri nella frase.
+//const NUMBERS_REGEX = /[0-9]+/;
+
+/* eslint-disable-next-line no-useless-escape */
+// Italian: Simboli non permessi, aggiungere anche qui sotto oltre che nella regex:
+// “ ” ‘ ’ ( ) É 
+//doppio " " e più di un "." nella stessa frase.
+const SYMBOL_REGEX = /[“”‘’\(\)É(\..*\.)(  )]/       //  original:   /[<>\+\*\\#@\^\[\]\(\)\/]/;
+// Any words consisting of uppercase letters or uppercase letters with a period
+// inbetween are considered abbreviations or acronyms.
+// This currently also matches fooBAR but we most probably don't want that either
+// as users wouldn't know how to pronounce the uppercase letters.
+const ABBREVIATION_REGEX = /[A-Z]{2,}|[A-Z]+\.*[A-Z]+/;
+
+
+export function getMaxLength() {
+  return MAX_WORDS;
+}
+
+export function getMinLength() {
+  return MIN_WORDS;
+}
+
+export function filterNumbers(sentence) {
+  //Italian: all numbers are allowed
+  //return !sentence.match(NUMBERS_REGEX);
+  return true;
+}
+
+export function filterAbbreviations(sentence) {
+  //Italian: non abbiamo regole particolari sulle abbreviazioni
+  //return !sentence.match(ABBREVIATION_REGEX);
+  return true;
+}
+
+export function filterSymbols(sentence) {
+  return !sentence.match(SYMBOL_REGEX);
+}

--- a/shared/validation/languages/it.js
+++ b/shared/validation/languages/it.js
@@ -18,6 +18,7 @@ const SYMBOL_REGEX = /[“”‘’\(\)É]| {2,}|\..*\./       //  original:   /
 // inbetween are considered abbreviations or acronyms.
 // This currently also matches fooBAR but we most probably don't want that either
 // as users wouldn't know how to pronounce the uppercase letters.
+//Versione italiana: dag7dev
 const ABBREVIATION_REGEX = /[A-Z][a-z]{2,}|[A-Z][a-z]+\.*[A-Z][a-z]+/;
 
 

--- a/shared/validation/languages/it.js
+++ b/shared/validation/languages/it.js
@@ -7,13 +7,13 @@ const MAX_WORDS = 17;
 
 // Numbers that are not allowed in a sentence depending on the language. For
 // Italian: tutti i numeri sono consentiti ma se e quando avremo la possibilità di fare regole personalizzate metteremo una condizione ulteriore sulla lunghezza se vi sono dei numeri nella frase.
-//const NUMBERS_REGEX = /[0-9]+/;
+const NUMBERS_REGEX = /[0-9]+/;
 
 /* eslint-disable-next-line no-useless-escape */
 // Italian: Simboli non permessi, aggiungere anche qui sotto oltre che nella regex:
 // “ ” ‘ ’ ( ) É 
 //doppio " " e più di un "." nella stessa frase.
-const SYMBOL_REGEX = /[“”‘’\(\)É]| {2,}|\..*\./       //  original:   /[<>\+\*\\#@\^\[\]\(\)\/]/;
+const SYMBOL_REGEX = /[“”‘’()É]| {2,}|\..*\./;       //  original:   /[<>\+\*\\#@\^\[\]\(\)\/]/;
 // Any words consisting of uppercase letters or uppercase letters with a period
 // inbetween are considered abbreviations or acronyms.
 // This currently also matches fooBAR but we most probably don't want that either
@@ -32,14 +32,14 @@ export function getMinLength() {
 
 export function filterNumbers(sentence) {
   //Italian: all numbers are allowed
-  //return !sentence.match(NUMBERS_REGEX);
-  return true;
+  var filter = !sentence.match(NUMBERS_REGEX);
+  return true || filter;
 }
 
 export function filterAbbreviations(sentence) {
   //Italian: non abbiamo regole particolari sulle abbreviazioni
-  //return !sentence.match(ABBREVIATION_REGEX);
-  return true;
+  var filter = !sentence.match(ABBREVIATION_REGEX);
+  return true || filter;
 }
 
 export function filterSymbols(sentence) {


### PR DESCRIPTION
We added a validator for the italian language matching the [Mozilla Italia guidelines](https://github.com/Sav22999/Guide/blob/master/Mozilla%20Italia/Common%20Voice/Linee%20guida%20revisione%20Common%20Voice.md) according to which sentences for the italian dataset of Common Voice have been selected up to now. 