### PR TITLE
Give more freedom in validating sentence length

### DIFF
--- a/shared/validation/index.js
+++ b/shared/validation/index.js
@@ -1,5 +1,3 @@
-import tokenizeWords from 'talisman/tokenizers/words';
-
 import * as en from './languages/en';
 import * as it from './languages/it';
 
@@ -66,20 +64,12 @@ function validateSentence(validator, sentence) {
 }
 
 function validateCorrectLength(validator, sentence) {
-  let maxLength = 0;
-  let minLength = 0;
+  const result =
+    typeof validator.filterNumbers !== 'function' ?
+      DEFAULT_VALIDATOR.filterNumbers(sentence) :
+      validator.filterNumbers(sentence);
 
-  if (typeof validator.getMaxLength !== 'function') {
-    maxLength = DEFAULT_VALIDATOR.getMaxLength();
-    minLength = DEFAULT_VALIDATOR.getMinLength();
-  } else {
-    maxLength = validator.getMaxLength();
-    minLength = validator.getMinLength();
-  }
-
-  const words = tokenizeWords(sentence);
-  return words.length >= minLength &&
-    words.length <= maxLength;
+  return result;
 }
 
 function validateWithoutNumbers(validator, sentence) {

--- a/shared/validation/index.js
+++ b/shared/validation/index.js
@@ -66,8 +66,8 @@ function validateSentence(validator, sentence) {
 function validateCorrectLength(validator, sentence) {
   const result =
     typeof validator.filterNumbers !== 'function' ?
-      DEFAULT_VALIDATOR.filterNumbers(sentence) :
-      validator.filterNumbers(sentence);
+      DEFAULT_VALIDATOR.filterLength(sentence) :
+      validator.filterLength(sentence);
 
   return result;
 }

--- a/shared/validation/languages/en.js
+++ b/shared/validation/languages/en.js
@@ -1,3 +1,5 @@
+import tokenizeWords from 'talisman/tokenizers/words';
+
 // Minimum of words that qualify as a sentence.
 const MIN_WORDS = 1;
 
@@ -19,14 +21,6 @@ const SYMBOL_REGEX = /[<>\+\*\\#@\^\[\]\(\)\/]/;
 // as users wouldn't know how to pronounce the uppercase letters.
 const ABBREVIATION_REGEX = /[A-Z]{2,}|[A-Z]+\.*[A-Z]+/;
 
-export function getMaxLength() {
-  return MAX_WORDS;
-}
-
-export function getMinLength() {
-  return MIN_WORDS;
-}
-
 export function filterNumbers(sentence) {
   return !sentence.match(NUMBERS_REGEX);
 }
@@ -37,4 +31,10 @@ export function filterAbbreviations(sentence) {
 
 export function filterSymbols(sentence) {
   return !sentence.match(SYMBOL_REGEX);
+}
+
+export function filterLength(sentence) {
+  const words = tokenizeWords(sentence);
+  return words.length >= MIN_WORDS &&
+    words.length <= MAX_WORDS;
 }

--- a/shared/validation/languages/it.js
+++ b/shared/validation/languages/it.js
@@ -1,9 +1,6 @@
-// Minimum of words that qualify as a sentence.
-const MIN_WORDS = 1;
-
-// Maximum of words allowed per sentence to keep recordings in a manageable duration. 
-// Italian: finché non abbiamo il controllo sui caratteri, o quello che tiene conto della presenza di numeri, metto 17 parole che dovrebbero essere salvo rarissimi casi sempre entro il limite di 125 caratteri. 
-const MAX_WORDS = 17;
+// According to Mozilla Italia guidelines, we count chars to validate instead of words.
+const MIN_LENGTH = 1;
+const MAX_LENGTH = 125;
 
 // Numbers that are not allowed in a sentence depending on the language.
 const NUMBERS_REGEX = /[0-9]+/;
@@ -20,15 +17,6 @@ const SYMBOL_REGEX = /[<>+*\\#@^“”‘’(){}É[\]/]|\s{2,}|\..*\./;
 // Versione italiana: dag7dev
 const ABBREVIATION_REGEX = /[A-Z]{2,}|[A-Z][a-z]+\.*[A-Z]+/;
 
-
-export function getMaxLength() {
-  return MAX_WORDS;
-}
-
-export function getMinLength() {
-  return MIN_WORDS;
-}
-
 export function filterNumbers(sentence) {
   return !sentence.match(NUMBERS_REGEX);
 }
@@ -39,4 +27,8 @@ export function filterAbbreviations(sentence) {
 
 export function filterSymbols(sentence) {
   return !sentence.match(SYMBOL_REGEX);
+}
+
+export function filterLength(sentence) {
+  return sentence.length >= MIN_LENGTH && sentence.length <= MAX_LENGTH;
 }


### PR DESCRIPTION
Currently, when creating a validator for a new language, the check on sentence length can only be customized by changing the number of words it counts in a sentence. However, there are languages like Chinese or Japanese where there's often no white spaces between words. At the moment it is impossible for users of those languages to create their own validation without changing the general one. 

Furthermore, the Italian Mozilla community has until now used "at most 125 characters" as a criterion for validating sentences, and such a rule can't be enforced cleanly as of now by only editing the Italian validator. It is very important that we are able to provide sentences coherent in length to those already in the data set as neural network models like DeepSpeech benefit a lot from uniformly shaped inputs. 

So, my modifications allow validators of new languages to handle the length limit more freely, while not changing the way length validation is done with regards to the English language. 