### PR TITLE
Checking whether the sentence contains [?!] in the middle

### DIFF
--- a/shared/validation/index.js
+++ b/shared/validation/index.js
@@ -60,6 +60,11 @@ function validateSentence(validator, sentence) {
     return validationResult;
   }
 
+  if (!validateStructure(validator, sentence)) {
+    validationResult.error = 'Contains multiple sentences';
+    return validationResult;
+  }
+
   return validationResult;
 }
 
@@ -95,6 +100,15 @@ function validateWithoutSymbols(validator, sentence) {
     typeof validator.filterSymbols !== 'function' ?
       DEFAULT_VALIDATOR.filterSymbols(sentence) :
       validator.filterSymbols(sentence);
+
+  return result;
+}
+
+function validateStructure(validator, sentence) {
+  const result =
+    typeof validator.filterStructure !== 'function' ?
+      DEFAULT_VALIDATOR.filterStructure(sentence) :
+      validator.filterStructure(sentence);
 
   return result;
 }

--- a/shared/validation/index.js
+++ b/shared/validation/index.js
@@ -1,5 +1,3 @@
-import tokenizeWords from 'talisman/tokenizers/words';
-
 import * as en from './languages/en';
 import * as it from './languages/it';
 
@@ -66,20 +64,12 @@ function validateSentence(validator, sentence) {
 }
 
 function validateCorrectLength(validator, sentence) {
-  let maxLength = 0;
-  let minLength = 0;
+  const result =
+    typeof validator.filterNumbers !== 'function' ?
+      DEFAULT_VALIDATOR.filterNumbers(sentence) :
+      validator.filterNumbers(sentence);
 
-  if (typeof validator.getMaxLength !== 'function') {
-    maxLength = DEFAULT_VALIDATOR.getMaxLength();
-    minLength = DEFAULT_VALIDATOR.getMinLength();
-  } else {
-    maxLength = validator.getMaxLength();
-    minLength = validator.getMinLength();
-  }
-
-  const words = tokenizeWords(sentence);
-  return words.length >= minLength &&
-    words.length <= maxLength;
+  return result;
 }
 
 function validateWithoutNumbers(validator, sentence) {

--- a/shared/validation/index.js
+++ b/shared/validation/index.js
@@ -66,8 +66,8 @@ function validateSentence(validator, sentence) {
 function validateCorrectLength(validator, sentence) {
   const result =
     typeof validator.filterNumbers !== 'function' ?
-      DEFAULT_VALIDATOR.filterNumbers(sentence) :
-      validator.filterNumbers(sentence);
+      DEFAULT_VALIDATOR.filterLength(sentence) :
+      validator.filterLength(sentence);
 
   return result;
 }

--- a/shared/validation/languages/en.js
+++ b/shared/validation/languages/en.js
@@ -10,6 +10,10 @@ const MAX_WORDS = 14;
 // English this is 0-9 once or multiple times after each other.
 const NUMBERS_REGEX = /[0-9]+/;
 
+// Checks whether the sentence has a ? or ! character in the middle, as it could mean 
+// more sentences per line.
+const STRUCTURE_REGEX = /[?!].+/;
+
 // The following symbols are disallowed, please update here as well and not just the regex
 // to make it easier to read:
 // < > + * \ # @ ^ [ ] ( ) /
@@ -31,6 +35,10 @@ export function filterAbbreviations(sentence) {
 
 export function filterSymbols(sentence) {
   return !sentence.match(SYMBOL_REGEX);
+}
+
+export function filterStructure(sentence) {
+  return !sentence.match(STRUCTURE_REGEX);
 }
 
 export function filterLength(sentence) {

--- a/shared/validation/languages/en.js
+++ b/shared/validation/languages/en.js
@@ -1,3 +1,5 @@
+import tokenizeWords from 'talisman/tokenizers/words';
+
 // Minimum of words that qualify as a sentence.
 const MIN_WORDS = 1;
 
@@ -19,14 +21,6 @@ const SYMBOL_REGEX = /[<>\+\*\\#@\^\[\]\(\)\/]/;
 // as users wouldn't know how to pronounce the uppercase letters.
 const ABBREVIATION_REGEX = /[A-Z]{2,}|[A-Z]+\.*[A-Z]+/;
 
-export function getMaxLength() {
-  return MAX_WORDS;
-}
-
-export function getMinLength() {
-  return MIN_WORDS;
-}
-
 export function filterNumbers(sentence) {
   return !sentence.match(NUMBERS_REGEX);
 }
@@ -37,4 +31,10 @@ export function filterAbbreviations(sentence) {
 
 export function filterSymbols(sentence) {
   return !sentence.match(SYMBOL_REGEX);
+}
+
+export function filterLength(sentence) {
+  const words = tokenizeWords(sentence);
+  return words.length >= MIN_WORDS &&
+    words.length <= MAX_WORDS;
 }

--- a/shared/validation/languages/it.js
+++ b/shared/validation/languages/it.js
@@ -5,11 +5,15 @@ const MAX_LENGTH = 125;
 // Numbers that are not allowed in a sentence depending on the language.
 const NUMBERS_REGEX = /[0-9]+/;
 
+// Checks whether the sentence has a ? or ! character in the middle, as it could mean 
+// more sentences per line.
+const STRUCTURE_REGEX = /[?!.].+/;
+
 /* eslint-disable-next-line no-useless-escape */
 // Italian: Simboli non permessi, aggiungere anche qui sotto oltre che nella regex:
 // < > + * \ # @ ^ “ ” ‘ ’ ( ) É [ ] / { }
 //doppio " " e più di un "." nella stessa frase.
-const SYMBOL_REGEX = /[<>+*\\#@^“”‘’(){}É[\]/]|\s{2,}|!{2,}|\..*\./;
+const SYMBOL_REGEX = /[<>+*\\#@^“”‘’(){}É[\]/]|\s{2,}|!{2,}/;
 // Any words consisting of uppercase letters or uppercase letters with a period
 // inbetween are considered abbreviations or acronyms.
 // This currently also matches fooBAR but we most probably don't want that either
@@ -29,6 +33,11 @@ export function filterSymbols(sentence) {
   return !sentence.match(SYMBOL_REGEX);
 }
 
+export function filterStructure(sentence) {
+  return !sentence.match(STRUCTURE_REGEX);
+}
+
 export function filterLength(sentence) {
-  return sentence.length >= MIN_LENGTH && sentence.length <= MAX_LENGTH;
+  return sentence.length >= MIN_LENGTH 
+      && sentence.length <= MAX_LENGTH;
 }

--- a/shared/validation/languages/it.js
+++ b/shared/validation/languages/it.js
@@ -1,9 +1,6 @@
-// Minimum of words that qualify as a sentence.
-const MIN_WORDS = 1;
-
-// Maximum of words allowed per sentence to keep recordings in a manageable duration. 
-// Italian: finché non abbiamo il controllo sui caratteri, o quello che tiene conto della presenza di numeri, metto 17 parole che dovrebbero essere salvo rarissimi casi sempre entro il limite di 125 caratteri. 
-const MAX_WORDS = 17;
+// According to Mozilla Italia guidelines, we count chars to validate instead of words.
+const MIN_LENGTH = 1;
+const MAX_LENGTH = 125;
 
 // Numbers that are not allowed in a sentence depending on the language.
 const NUMBERS_REGEX = /[0-9]+/;
@@ -20,15 +17,6 @@ const SYMBOL_REGEX = /[<>+*\\#@^“”‘’(){}É[\]/]|\s{2,}|\..*\./;
 // Versione italiana: dag7dev
 const ABBREVIATION_REGEX = /[A-Z]{2,}|[A-Z][a-z]+\.*[A-Z]+/;
 
-
-export function getMaxLength() {
-  return MAX_WORDS;
-}
-
-export function getMinLength() {
-  return MIN_WORDS;
-}
-
 export function filterNumbers(sentence) {
   return !sentence.match(NUMBERS_REGEX);
 }
@@ -39,4 +27,8 @@ export function filterAbbreviations(sentence) {
 
 export function filterSymbols(sentence) {
   return !sentence.match(SYMBOL_REGEX);
+}
+
+export function filterLength(sentence) {
+  return sentence.length >= MIN_LENGTH && sentence.length <= MAX_LENGTH;
 }

--- a/shared/validation/languages/it.js
+++ b/shared/validation/languages/it.js
@@ -9,7 +9,7 @@ const NUMBERS_REGEX = /[0-9]+/;
 // Italian: Simboli non permessi, aggiungere anche qui sotto oltre che nella regex:
 // < > + * \ # @ ^ “ ” ‘ ’ ( ) É [ ] / { }
 //doppio " " e più di un "." nella stessa frase.
-const SYMBOL_REGEX = /[<>+*\\#@^“”‘’(){}É[\]/]|\s{2,}|\..*\./;
+const SYMBOL_REGEX = /[<>+*\\#@^“”‘’(){}É[\]/]|\s{2,}|!{2,}|\..*\./;
 // Any words consisting of uppercase letters or uppercase letters with a period
 // inbetween are considered abbreviations or acronyms.
 // This currently also matches fooBAR but we most probably don't want that either


### PR DESCRIPTION
As discussed in #202, I've added a check for those characters in the middle of a sentence as they mean it's two sentences. In the Italian version we already handled `.` in the middle so it now checks for `[?!.]`.