### PR TITLE
Update record approval logic

### DIFF
--- a/shared/db/collections/sentences-meta.js
+++ b/shared/db/collections/sentences-meta.js
@@ -352,11 +352,13 @@ export default class SentencesMeta {
     const invalidVotes = record.invalid.length;
     const totalVotes = validVotes + invalidVotes;
 
-    if (totalVotes < APPROVAL_MIN_TOTAL_VOTES) {
-      return;
+    if(validVotes >= APPROVAL_MIN_VALID_VOTES) {
+      return true;
+    } else if(totalVotes >= APPROVAL_MIN_TOTAL_VOTES) {
+      return false;
     }
 
-    return validVotes >= APPROVAL_MIN_VALID_VOTES;
+    return;
   }
 
   async vote(language, validated, invalidated) {


### PR DESCRIPTION
A record needs at least two "valid votes" to get into the approved state. If a record was reviewed by at least 3 persons and and there are not at least two valid votes, the record is marked as invalid.
This refactoring does not change this logic, but allows records to be moved to the approved state already after two reviews (if both approve the record).
This optimizes the review-time, as the third reviewer would have no effect.
Fixes #224