### PR TITLE
Remove mentions of Opensubtitles.org and Common Crawl from how-to

### DIFF
--- a/doc/how-to.md
+++ b/doc/how-to.md
@@ -36,7 +36,6 @@ Here are some tips to find sentences:
 - The best sources you can look for are podcasts, transcripts, movie scripts and anything that potential can contain everyday conversations.
 - Government proceedings, books and articles are also great however since the text tends to be a little more formal they are less of a priority.
 - Unfortunately we can’t have Wikimedia articles yet. So do not copy paste from there.
-- Two great resources to look into are: [Common Crawl](https://commoncrawl.org/) and [Open Subtitles](https://www.opensubtitles.org/). Not all of the content on these websites are Public Domain, so please check before using them (for examples movie scripts might still be copyrighted and couldn't be used in Common Voice).
 
 ### Partner with local organizations or individuals
 


### PR DESCRIPTION
This is very misleading links, especially with talking about how good subtitles for dataset is and then mentioning *open*subtitles, which are actually copyrighted. This sources contains mostly copyrighted content and do not provide an easy way to filter for PD content. Contributors interpret this links as a call to action and spend time to contribute sentences which we can't use. It already happened [with Swedish](https://discourse.mozilla.org/t/discussion-of-new-guidelines-for-uploaded-sentence-validation/37718/11), [Czech](https://github.com/Common-Voice/sentence-collector/issues/211#issuecomment-491522940) and now Russian.