### PR TITLE
Few rules of validation, have been changed for Odia language.

### DIFF
--- a/shared/validation/index.js
+++ b/shared/validation/index.js
@@ -1,10 +1,13 @@
 import * as en from './languages/en';
 import * as it from './languages/it';
 import * as ne from './languages/ne';
+import * as od from './languages/od';
+
 const VALIDATORS = {
   en,
   it,
-  ne
+  ne,
+  od,
 };
 
 const DEFAULT_VALIDATOR_LANGUAGE = 'en';

--- a/shared/validation/languages/od.js
+++ b/shared/validation/languages/od.js
@@ -1,0 +1,52 @@
+import tokenizeWords from 'talisman/tokenizers/words';
+
+// Minimum of words that qualify as a sentence.
+const MIN_WORDS = 1;
+
+// Maximum of words allowed per sentence to keep recordings in a manageable duration.
+// This got increased from 14 to 30 as per easiness in creation of meaningful sentences.
+const MAX_WORDS = 30;
+
+// Numbers that are not allowed in a sentence depending on the language. For
+// English this is 0-9 once or multiple times after each other.
+// Odia numbers added along with English numbers
+const NUMBERS_REGEX = /[୦୧୨୩୪୫୬୭୮୯0-9]+/;
+
+// Some languages want to check the structure, this is what this REGEX is for. For English
+// (and by extend as default) we're not currently using it.
+/* eslint-disable-next-line no-unused-vars */
+const STRUCTURE_REGEX = undefined;
+
+// The following symbols are disallowed, please update here as well and not just the regex
+// to make it easier to read:
+// < > + * \ # @ ^ [ ] ( ) /
+/* eslint-disable-next-line no-useless-escape */
+const SYMBOL_REGEX = /[<>\+\*\\#@\^\[\]\(\)\/]/;
+// Any words consisting of uppercase letters or uppercase letters with a period
+// inbetween are considered abbreviations or acronyms.
+// This currently also matches fooBAR but we most probably don't want that either
+// as users wouldn't know how to pronounce the uppercase letters.
+const ABBREVIATION_REGEX = /[A-Z]{2,}|[A-Z]+\.*[A-Z]+/;
+
+export function filterNumbers(sentence) {
+  return !sentence.match(NUMBERS_REGEX);
+}
+
+export function filterAbbreviations(sentence) {
+  return !sentence.match(ABBREVIATION_REGEX);
+}
+
+export function filterSymbols(sentence) {
+  return !sentence.match(SYMBOL_REGEX);
+}
+
+/* eslint-disable-next-line no-unused-vars */
+export function filterStructure(sentence) {
+  return true;
+}
+
+export function filterLength(sentence) {
+  const words = tokenizeWords(sentence);
+  return words.length >= MIN_WORDS &&
+    words.length <= MAX_WORDS;
+}


### PR DESCRIPTION
Changes are done for Odia language sentences validation are:  

1. Maximum words for validation have been increased from `14` to `30`. This is to get a meaningful sentence Odia language needs more words. Visit the [Discourse](https://discourse.mozilla.org/t/increase-the-number-of-words-limit-for-odia/41713) discussion topic for details.
2. Odia digits have been added to the digits detector RegEx.