### PR TITLE
fix: remove try/catch that eslint(commit c214e89a) causes to break build

### DIFF
--- a/web/src/actions/index.js
+++ b/web/src/actions/index.js
@@ -95,19 +95,15 @@ export function removeLanguage(language) {
 
 export function submitSentences(language, sentences, source) {
   return async function(dispatch, getState) {
-    try {
-      dispatch(sendSubmitSentences());
+    dispatch(sendSubmitSentences());
 
-      const state = getState();
-      const db = new WebDB(state.app.username, state.app.password);
-      const results = await db.submitSentences(language, sentences, source);
-      dispatch(submitSentencesSuccess(results.sentences.slice(0)));
-      const errorsWithSentenceInfo = results.errors.filter((error) => error.sentence);
-      dispatch(submitSentencesFailureSingle(errorsWithSentenceInfo));
-      return results;
-    } catch (err) {
-      throw err;
-    }
+    const state = getState();
+    const db = new WebDB(state.app.username, state.app.password);
+    const results = await db.submitSentences(language, sentences, source);
+    dispatch(submitSentencesSuccess(results.sentences.slice(0)));
+    const errorsWithSentenceInfo = results.errors.filter((error) => error.sentence);
+    dispatch(submitSentencesFailureSingle(errorsWithSentenceInfo));
+    return results;
   };
 }
 


### PR DESCRIPTION
ESLint was upgraded directly in master but broke the builds since it added some additional requirements.   This fixes that requirement.

Commit that broke it:
https://github.com/Common-Voice/sentence-collector/commit/c214e89a602833382b6d71b88d9ed4f37f41b8d0

This catch was just re-throwing the error so it wasn't needed