### PR TITLE
chore: use IP for helper scripts

### DIFF
--- a/scripts/db-helper.js
+++ b/scripts/db-helper.js
@@ -71,13 +71,13 @@ async function initDB() {
 }
 
 async function deleteSentences() {
-  const remoteHost = system === 'production' ? prodRemote : remote;
+  const remoteHost = system === 'production' ? prodRemoteIP : remote;
   const db = new DB(remoteHost, username, password);
   await db.deleteSentenceRecords();
 }
 
 async function deleteSpecificSentences() {
-  const remoteHost = system === 'production' ? prodRemote : remote;
+  const remoteHost = system === 'production' ? prodRemoteIP : remote;
   const db = new DB(remoteHost, username, password);
   if (!deleteLocale || !deleteUsername) {
     fail('DELETE_SPECIFIC_LOCALE and DELETE_SPECIFIC_USERNAME are required');
@@ -89,7 +89,7 @@ async function deleteSpecificSentences() {
 }
 
 async function forceDeleteFile() {
-  const remoteHost = system === 'production' ? prodRemote : remote;
+  const remoteHost = system === 'production' ? prodRemoteIP : remote;
   const db = new DB(remoteHost, username, password);
   if (!deleteLocale || !deleteFile) {
     fail('DELETE_SPECIFIC_LOCALE and DELETE_SPECIFIC_SENTENCES_FILE are required');
@@ -106,7 +106,7 @@ async function forceDeleteFile() {
 }
 
 async function forceDeleteSpecificSentences() {
-  const remoteHost = system === 'production' ? prodRemote : remote;
+  const remoteHost = system === 'production' ? prodRemoteIP : remote;
   const db = new DB(remoteHost, username, password);
   if (!deleteLocale || !deleteUsername) {
     fail('DELETE_SPECIFIC_LOCALE and DELETE_SPECIFIC_USERNAME are required');
@@ -116,13 +116,13 @@ async function forceDeleteSpecificSentences() {
 }
 
 async function correctApprovals(locale) {
-  const remoteHost = system === 'production' ? prodRemote : remote;
+  const remoteHost = system === 'production' ? prodRemoteIP : remote;
   const db = new DB(remoteHost, username, password);
   await db.correctApprovals(locale);
 }
 
 async function deleteVotes() {
-  const remoteHost = system === 'production' ? prodRemote : remote;
+  const remoteHost = system === 'production' ? prodRemoteIP : remote;
   const db = new DB(remoteHost, username, password);
   if (!deleteLocale || !deleteUsername) {
     fail('DELETE_SPECIFIC_LOCALE and DELETE_SPECIFIC_USERNAME are required');


### PR DESCRIPTION
Something with the Nginx Proxy makes the `next` function for pagination not behave as it should. Using the IP works perfectly fine. As I don't have access to the nginx configuration or the server itself, and I don't think we'll get engineering time from people who do have access, let's just use the IP for now. 