### PR TITLE
chore: improve export performance (fixes #253)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
   ],
   "rules": {
     "no-console": "off",
-    "semi": "error"
+    "semi": "error",
+    "no-prototype-builtins": "off"
   },
   "plugins": [
     "react",

--- a/scripts/exporter.js
+++ b/scripts/exporter.js
@@ -95,7 +95,11 @@ function dedupeSentences(languageCode, sentences, path) {
   const numberOfDupes = sentences.length - dedupedSentences.length;
   console.log(`  - Got ${numberOfDupes} duplicated sentences in Sentence Collector..`);
 
-  const notAlreadyExistingInCV = dedupedSentences.filter((sentence) => !alreadyExistingCVSentences.includes(sentence));
+  const cvSentences = alreadyExistingCVSentences.reduce((acc, sentence) => {
+    acc[sentence] = true;
+    return acc;
+  }, {});
+  const notAlreadyExistingInCV = dedupedSentences.filter((sentence) => !cvSentences[sentence]);
   console.log(`  - Got ${notAlreadyExistingInCV.length} sentences not already existing in CV..`);
   return notAlreadyExistingInCV;
 }

--- a/scripts/exporter.js
+++ b/scripts/exporter.js
@@ -99,7 +99,7 @@ function dedupeSentences(languageCode, sentences, path) {
     acc[sentence] = true;
     return acc;
   }, {});
-  const notAlreadyExistingInCV = dedupedSentences.filter((sentence) => !cvSentences[sentence]);
+  const notAlreadyExistingInCV = dedupedSentences.filter((sentence) => !cvSentences.hasOwnProperty(sentence));
   console.log(`  - Got ${notAlreadyExistingInCV.length} sentences not already existing in CV..`);
   return notAlreadyExistingInCV;
 }


### PR DESCRIPTION
Thanks to @freaktechnik for this idea on how to improve the performance.

Before:

```
Starting export for de..
  - Found 17700 approved sentences
  - Found 17700 valid sentences
  - Writing all meta data to ../voice-web/server/data/de/sentence-collector.json..
  - Cleaning up sentences
  - Getting CV sentences for de..
  - Got 1396914 CV sentences..
  - Got 9 duplicated sentences in Sentence Collector..
CHECK_CV_DUPES: 104398.344ms
  - Got 17645 sentences not already existing in CV..
  - Writing all sentences to ../voice-web/server/data/de/sentence-collector.txt..
```

After:

```
Starting export for de..
  - Found 17700 approved sentences
  - Found 17700 valid sentences
  - Writing all meta data to ../voice-web/server/data/de/sentence-collector.json..
  - Cleaning up sentences
  - Getting CV sentences for de..
  - Got 1396914 CV sentences..
  - Got 9 duplicated sentences in Sentence Collector..
CHECK_CV_DUPES: 2518.392ms
  - Got 17645 sentences not already existing in CV..
  - Writing all sentences to ../voice-web/server/data/de/sentence-collector.txt..
```