### PR TITLE
feat: mobile swipecards based UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6920,6 +6920,11 @@
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
+    "hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
+    },
     "handlebars": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "connected-react-router": "^6.5.2",
     "es6-promisify": "^6.0.1",
+    "hammerjs": "^2.0.8",
     "hash.js": "^1.1.7",
     "iso-639-1": "^2.0.5",
     "kinto": "^12.6.0",

--- a/web/css/review-form.css
+++ b/web/css/review-form.css
@@ -7,7 +7,7 @@
   padding: 0;
 }
 
-.sentence-box {
+.sentence-box, .card-sentence-box {
   height: 6rem;
   border: 1px solid var(--grey-color);
   flex-basis: 100%;
@@ -99,3 +99,37 @@
   box-shadow: none;
 }
 
+.master-root {
+  margin: 20px auto;
+  position: relative;
+  height: calc(6rem + 120px + 2em);
+  width: calc(380px + 2em);
+  overflow: hidden;
+  border: 1px solid #e5e5e5;
+}
+
+.card {
+  background-size: cover;
+  position: absolute;
+  background: #F8F3F3;
+  height: 6rem;
+  width: 250px;
+  margin: 0 auto;
+  transition: box-shadow .3s;
+  box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
+  cursor: pointer;
+  padding: 1em;
+}
+
+.animate {
+  transition: transform .3s;
+  box-shadow: none;
+}
+
+.inactive {
+  box-shadow: none;
+}
+
+.card-sentence-box {
+  border: none !important;
+}

--- a/web/css/review-form.css
+++ b/web/css/review-form.css
@@ -131,5 +131,5 @@
 }
 
 .card-sentence-box {
-  border: none !important;
+  border: none;
 }

--- a/web/css/review-form.css
+++ b/web/css/review-form.css
@@ -123,8 +123,8 @@
 .master-root {
   margin: 20px auto;
   position: relative;
-  height: calc(6rem + 120px + 2em);
-  width: calc(380px + 2em);
+  height: calc(6rem + 2em);
+  width: calc(250px + 2em);
   overflow: hidden;
   border: 1px solid #e5e5e5;
 }
@@ -135,7 +135,6 @@
   background: #F8F3F3;
   height: 6rem;
   width: 250px;
-  margin: 0 auto;
   transition: box-shadow .3s;
   box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);
   cursor: pointer;

--- a/web/src/components/review-form.jsx
+++ b/web/src/components/review-form.jsx
@@ -10,7 +10,7 @@ const PAGE_SIZE = 5;
 const DEFAULT_STATE = {
   page: 0,
 };
-let mobileUI = true;
+let mobileUI = false;
 
 export default class ReviewForm extends React.Component {
   constructor(props) {
@@ -102,48 +102,37 @@ export default class ReviewForm extends React.Component {
     const curSentences = this.props.sentences.slice(offset, offset + PAGE_SIZE);
 
     if (mobileUI) {
-      let message = (<p>Swipe right to approve sentencee, swipe left to reject it.</p>);
+      let message = (<p>You have not reviewed any sentences yet!</p>);
       if (this.state.page !== 0) {
-        message = (<p>You have succesfully reviewed your {this.state.page * PAGE_SIZE}th sentence!</p>)
+        message = (<p>You have successfully reviewed your {this.state.page * PAGE_SIZE}th sentence!</p>)
       }
 
       return (
         <form id="review-form" onSubmit={this.onSubmit}>
+          <p>Swipe right to approve sentence, swipe left to reject it.</p>
           {message}
-        <Cards onEnd={() => {
-          if (this.state.page === this.getLastPage()) {
-            this.onSubmit({preventDefault: ()=>{}});
-          } else {
-            this.setPage(this.state.page + 1);
-            this.cardsRef.current.setState({index: -1});//cardsRef.state.index modified due to Cards' inner card removal handling.
-          }
-        }} className="master-root" ref={this.cardsRef}>
-          {curSentences.map((sentence, i) => (
-            <Card
-              key={offset + i}
-              onSwipeLeft={() => this.reviewSentence(offset + i, false)}
-              onSwipeRight={() => this.reviewSentence(offset + i, true)}
-            >
-              <div className="card-sentence-box">
-                {sentence.sentence || sentence}
-              </div>
-            </Card>
-          ))}
-        </Cards>
-          <section className="review-footer">
-          <section id="confirm-buttons" className="divCenter">
-            { this.state.pendingSentences ?
-              <SpinnerButton></SpinnerButton> :
-              <button type="submit">Finish Review</button>
+          <Cards onEnd={() => {
+            if (this.state.page === this.getLastPage()) {
+              this.onSubmit({preventDefault: ()=>{}});
+            } else {
+              this.setPage(this.state.page + 1);
+              this.cardsRef.current.setState({index: -1});//cardsRef.state.index modified due to Cards' inner card removal handling.
             }
-
-            { this.state.pendingSentences && (
-              <div>
-                <p className="loadingText">Reviews are being uploaded. This can take several minutes depending on the number of sentences added.
-                  Please don't close this website.</p>
-              </div>
-            )}
-          </section>
+          }} className="master-root" ref={this.cardsRef}>
+            {curSentences.map((sentence, i) => (
+              <Card
+                key={offset + i}
+                onSwipeLeft={() => this.reviewSentence(offset + i, false)}
+                onSwipeRight={() => this.reviewSentence(offset + i, true)}
+              >
+                <div className="card-sentence-box">
+                  {sentence.sentence || sentence}
+                </div>
+              </Card>
+            ))}
+          </Cards>
+          <section className="review-footer">
+          <ConfirmButtons pendingSentences={this.state.pendingSentences}/>
           </section>
         </form>
       );
@@ -178,20 +167,7 @@ export default class ReviewForm extends React.Component {
         )) }
 
         <section className="review-footer">
-          <section id="confirm-buttons" className="divCenter">
-            { this.state.pendingSentences ?
-              <SpinnerButton></SpinnerButton> :
-              <button type="submit">Finish Review</button>
-            }
-
-            { this.state.pendingSentences && (
-              <div>
-                <p className="loadingText">Reviews are being uploaded. This can take several minutes depending on the number of sentences added.
-                  Please don't close this website.</p>
-              </div>
-            )}
-          </section>
-
+          <ConfirmButtons pendingSentences={this.state.pendingSentences}/>
           <Pager page={this.state.page} lastPage={this.getLastPage()}
                  onPage={this.setPage} />
         </section>
@@ -224,4 +200,20 @@ const Pager = (props) => (
       }</span>
     ))
   }</section>
+);
+
+const ConfirmButtons = (props) => (
+  <section id="confirm-buttons" className="divCenter">
+    { props.pendingSentences ?
+      <SpinnerButton></SpinnerButton> :
+      <button type="submit">Finish Review</button>
+    }
+
+    { props.pendingSentences && (
+      <div>
+        <p className="loadingText">Reviews are being uploaded. This can take several minutes depending on the number of sentences added.
+          Please don&apos;t close this website.</p>
+      </div>
+    )}
+  </section>
 );

--- a/web/src/components/review-form.jsx
+++ b/web/src/components/review-form.jsx
@@ -3,11 +3,15 @@ import React from 'react';
 import '../../css/review-form.css';
 import SpinnerButton from './spinner-button';
 
+import Cards from './swipecard/Cards';
+import Card from "./swipecard/CardSwitcher";
+
 const PAGE_SIZE = 5;
 const DEFAULT_STATE = {
   page: 0,
   reviewed: [],
 };
+let mobileUI = true;
 
 export default class ReviewForm extends React.Component {
   constructor(props) {
@@ -38,6 +42,7 @@ export default class ReviewForm extends React.Component {
 
   async onSubmit(evt) {
     evt.preventDefault();
+    console.log("DDDDDD")
     let validated = [];
     let invalidated = [];
 
@@ -97,6 +102,24 @@ export default class ReviewForm extends React.Component {
 
     const offset = this.getOffset();
     const curSentences = this.props.sentences.slice(offset, offset + PAGE_SIZE);
+
+    if (mobileUI) {
+      return (
+        <Cards onEnd={() => this.onSubmit({'preventDefault': function () {}})} className="master-root">
+          {curSentences.map((sentence, i) => (
+            <Card
+              key={offset + i}
+              onSwipeLeft={() => this.reviewSentence(offset + i, false)}
+              onSwipeRight={() => this.reviewSentence(offset + i, true)}
+            >
+              <div className="card-sentence-box">
+                {sentence.sentence || sentence}
+              </div>
+            </Card>
+          ))}
+        </Cards>
+      );
+    }
 
     return (
       <form id="review-form" onSubmit={this.onSubmit}>

--- a/web/src/components/review-form.jsx
+++ b/web/src/components/review-form.jsx
@@ -132,7 +132,7 @@ export default class ReviewForm extends React.Component {
             ))}
           </Cards>
           <section className="review-footer">
-          <ConfirmButtons pendingSentences={this.state.pendingSentences}/>
+            <ConfirmButtons pendingSentences={this.state.pendingSentences}/>
           </section>
         </form>
       );

--- a/web/src/components/swipecard/CardSwitcher.jsx
+++ b/web/src/components/swipecard/CardSwitcher.jsx
@@ -1,0 +1,11 @@
+import { createElement } from 'react';
+
+import SimpleCard from './SimpleCard';
+import DraggableCard from './DraggableCard';
+
+const Card = ({ active = false, ...props }) => {
+  const component = active ? DraggableCard : SimpleCard;
+  return createElement(component, props);
+};
+
+export default Card;

--- a/web/src/components/swipecard/Cards.jsx
+++ b/web/src/components/swipecard/Cards.jsx
@@ -1,0 +1,81 @@
+import React, { Component, cloneElement } from 'react';
+import { DIRECTIONS } from './utils';
+
+class SwipeCards extends Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      index: 0,
+      alertLeft: false,
+      alertRight: false,
+      alertTop: false,
+      alertBottom: false,
+      containerSize: { x: 0, y: 0 }
+    };
+    this.removeCard = this.removeCard.bind(this);
+    this.setSize = this.setSize.bind(this);
+    this.myRef = React.createRef();
+  }
+
+  removeCard (side, cardId) {
+    const { children, onEnd } = this.props;
+    setTimeout(() => this.setState({ [`alert${side}`]: false }), 300);
+    
+    if (children.length === (this.state.index + 1) && onEnd) onEnd();
+
+    this.setState({
+      index: this.state.index + 1,
+      [`alert${side}`]: true
+    });
+  }
+  
+  componentDidMount () {
+    this.setSize();
+    window.addEventListener('resize', this.setSize);
+  }
+   componentWillUnmount () {
+    window.removeEventListener('resize', this.setSize);
+  }
+
+  setSize () {
+    const containerSize = {
+      x: this.myRef.current.offsetWidth,
+      y: this.myRef.current.offsetHeight
+    };
+    this.setState({ containerSize });
+  }
+
+  render () {
+    const { index, containerSize } = this.state;
+    const { children, className} = this.props;
+    if (!containerSize.x || !containerSize.y) return  <div className={className} ref={this.myRef}/>;
+
+    const _cards = children.reduce((memo, c, i) => {
+      if (index > i) return memo;
+      const props = {
+        key: i,
+        containerSize,
+        index: children.length - index,
+        ...DIRECTIONS.reduce((m, d) => 
+          ({ ...m, [`onOutScreen${d}`]: () => this.removeCard(d) }), {}),
+        active: index === i
+      };
+      return [ cloneElement(c, props), ...memo ];
+    }, []);
+    
+    return (
+      <div className={className} ref={this.myRef}>
+        {DIRECTIONS.map(d => 
+          <div key={d} className={`${this.state[`alert${d}`] ? 'alert-visible': ''} alert-${d.toLowerCase()} alert`}>
+            {this.props[`alert${d}`]}
+          </div>
+        )}
+        <div id='cards'>
+          {_cards}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default SwipeCards;

--- a/web/src/components/swipecard/DraggableCard.jsx
+++ b/web/src/components/swipecard/DraggableCard.jsx
@@ -1,0 +1,124 @@
+import React, { Component } from 'react';
+import Hammer from 'hammerjs';
+import SimpleCard from './SimpleCard';
+import { translate3d } from './utils';
+
+class DraggableCard extends Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      x: 0,
+      y: 0,
+      initialPosition: { x: 0, y: 0 },
+      startPosition: { x: 0, y: 0 },
+      animation: null,
+      pristine: true,
+      className: this.props.className || ''
+    };
+    this.resetPosition = this.resetPosition.bind(this);
+    this.handlePan = this.handlePan.bind(this);
+    this.myRef = React.createRef();
+  }
+  resetPosition () {
+    const { x, y } = this.props.containerSize;
+    const card = this.myRef.current.myRef.current;
+
+    const initialPosition = {
+      x: Math.round((x - card.offsetWidth) / 2),
+      y: Math.round((y - card.offsetHeight) / 2)
+    };
+
+    this.setState({
+      x: initialPosition.x,
+      y: initialPosition.y,
+      initialPosition: initialPosition,
+      startPosition: { x: 0, y: 0 }
+    });
+  }
+  
+  panstart () {
+    const { x, y } = this.state;
+    this.setState({
+      animation: false,
+      startPosition: { x, y },
+      pristine: false
+    });
+  }
+  panend () {
+    const screen = this.props.containerSize;
+    const card = this.myRef.current.myRef.current;
+
+    const getDirection = () => {
+      switch (true) {
+        case (this.state.x < -50): return 'Left';
+        case (this.state.x + (card.offsetWidth - 50) > screen.x): return 'Right';
+        default: return false;
+      }
+    };
+    const direction = getDirection();
+
+    if (this.props[`onSwipe${direction}`]) {
+      this.props[`onSwipe${direction}`]();
+      this.props[`onOutScreen${direction}`](this.props.index);
+    } else {
+      this.resetPosition();
+      this.setState({ animation: true });
+    }
+
+  }
+  panmove (ev) {
+    this.setState(this.calculatePosition( ev.deltaX, ev.deltaY ));
+  }
+  pancancel (ev) {
+    console.log(ev.type);
+  }
+
+  handlePan (ev) {
+    ev.preventDefault();
+    this[ev.type](ev);
+    return false;
+  }
+
+  handleSwipe (ev) {
+    console.log(ev.type);
+  }
+
+  calculatePosition (deltaX, deltaY) {
+    const { initialPosition : { x, y } } = this.state;
+    return {
+      x: (x + deltaX),
+      y: (y + deltaY)
+    };
+  }
+  componentDidMount () {
+    this.hammer = new Hammer.Manager(this.myRef.current.myRef.current);
+    this.hammer.add(new Hammer.Pan({ threshold: 2 }));
+    
+    this.hammer.on('panstart panend pancancel panmove', this.handlePan);
+    this.hammer.on('swipestart swipeend swipecancel swipemove', this.handleSwipe);
+
+    this.resetPosition();
+    window.addEventListener('resize', this.resetPosition);
+  }
+  componentWillUnmount () {
+    if (this.hammer) {
+      this.hammer.stop();
+      this.hammer.destroy();
+      this.hammer = null;
+    }
+    window.removeEventListener('resize', this.resetPosition);
+  }
+  render () {
+    const { x, y, animation, pristine, className } = this.state;
+    const style = translate3d(x, y);
+    return (
+      <SimpleCard
+        {...this.props}
+        style={style}
+        className={[className, animation ? 'animate' : pristine ? 'inactive' : ''].join(' ')}
+        ref={this.myRef}
+      />);
+  }
+}
+
+export default DraggableCard;

--- a/web/src/components/swipecard/NOTE
+++ b/web/src/components/swipecard/NOTE
@@ -1,0 +1,3 @@
+Included and edited from https://github.com/alexandre-garrec/react-swipe-card/
+
+Above Licensed under MIT, except with no provided copyright notice, which thus can't be included here.

--- a/web/src/components/swipecard/SimpleCard.jsx
+++ b/web/src/components/swipecard/SimpleCard.jsx
@@ -1,0 +1,46 @@
+import React, { Component } from 'react';
+import { translate3d } from './utils';
+
+class Card extends Component {
+  constructor (props) {
+    super(props);
+    this.state = { initialPosition: { x: 0, y: 0 } };
+    this.setInitialPosition = this.setInitialPosition.bind(this);
+    this.myRef = React.createRef();
+  }
+  setInitialPosition () {
+    const card = this.myRef.current;
+    const initialPosition = {
+      x: Math.round((this.props.containerSize.x - card.offsetWidth) / 2),
+      y: Math.round((this.props.containerSize.y - card.offsetHeight) / 2)
+    };
+    this.setState({ initialPosition });
+  }
+
+  componentDidMount () {
+    this.setInitialPosition();
+    window.addEventListener('resize', this.setInitialPosition);
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('resize', this.setInitialPosition);
+  }
+
+  render () {
+    const { initialPosition: { x, y } } = this.state;
+    const { className = 'inactive' } = this.props;
+    var style = {
+      ...translate3d(x, y),
+      zIndex: this.props.index,
+      ...this.props.style
+    };
+
+    return (
+      <div style={style} className={`card ${className}`} ref={this.myRef}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+export default Card;

--- a/web/src/components/swipecard/utils.jsx
+++ b/web/src/components/swipecard/utils.jsx
@@ -1,0 +1,11 @@
+
+export const translate3d = (x, y) => {
+  const translate = `translate3d(${x}px, ${y}px, 0px)`;
+  return {
+    msTransform: translate,
+    WebkitTransform: translate,
+    transform: translate
+  };
+};
+
+export const DIRECTIONS = [ 'Right', 'Left', 'Top', 'Bottom' ];


### PR DESCRIPTION
Adds a review UI mode for mobiles based on the concept of swipecards.
Basically uses https://github.com/alexandre-garrec/react-swipe-card, except its sources are directly included and somewhat edited, as I was not capable of getting it to run as is. I acknowledge that that is not an ideal solution, but consider it just a POC.
Whether the new or old UI is displayed is determined by a switch curretnly hardcoded, with no option to set from UI.
As of now, this just submits after every five sentences reviewed. That is completely fine, ecept it just fetches all the up to 10000 just after that again, and that is not good. Either add a separate submit button, or fetch only five sentences at time - though that would break the sentence sorting ATM.
This was not actually tested on mobile device due to how funky I'm connecting to my LAN. All testing was being done just in a resized desktop browser window.
Does not provide rollback functionality for now, which might eventually be deemed necessary (e.g. go to prev sentence and change how you swiped)
Does not provide any feedback as to the action taken by the swipe, some toast disaplying at least "accepted"/"rejected" would be nice to have.