### PR TITLE
Add Sicilian (ISO 639-2 scn)

### DIFF
--- a/shared/languages.js
+++ b/shared/languages.js
@@ -104,6 +104,11 @@ const ADDITIONAL_LANGUAGES = [
     nativeName: 'Саха тыла',
   },
   {
+    code: 'scn',
+    name: 'Sicilian',
+    nativeName: 'sicilianu',
+  },
+  {
     code: 'uby',
     name: 'Ubykh',
     nativeName: 'Ubykh',


### PR DESCRIPTION
Hello,
Sicilian (ISO 639-2 scn) has recently entered the Common Voice family. It's present in https://raw.githubusercontent.com/mozilla/voice-web/master/locales/all.json , but not in the sentence-collector webapp.

This commit should fix it -- thank you for considering it!