### PR TITLE
fix: add mapping for Hindi in exporter

### DIFF
--- a/scripts/exporter.js
+++ b/scripts/exporter.js
@@ -17,6 +17,7 @@ const LANGUAGE_MAPPING = {
   'ne-NP': 'ne',
   'sv-SE': 'sv',
   'pa-IN': 'pa',
+  'hi-IN': 'hi',
 };
 
 export async function startBackup(db, exportPath) {


### PR DESCRIPTION
Just noticed that the CV site is fully localized in `hi-IN` but it's `hi` on sentence-collector. 