### PR TITLE
Disallow emojis for Thai sentences

### DIFF
--- a/server/lib/cleanup/languages/th.js
+++ b/server/lib/cleanup/languages/th.js
@@ -18,29 +18,29 @@ function sortSentences(sentences) {
 function clean(sentences) {
   return sentences.map((sentence) => {
     return sentence
-      .replace(/[\u200b\u200c]/g, '')  // removes zero-width chars (occurs in some Thai texts)
-      .replace(/[^\s0-9\u0e01-\u0e2e\u0e30-\u0e39\u0e40-\u0e45\u0e47-\u0e4c\-\.‚;:“”‘’\u0022\u0027\u0060!\u003f]/g, '')  // allowed_symbols_regex
-      .replace(/:/g, ' : ') // add a space before and after colon
-      .replace(/\?/g, ' ? ') // adds a space before and after question mark
-      .replace(/!/g, ' ! ') // adds a space before and after exclamation mark
-      .replace(/,/g, ' ') // replaces comma with space
-      .replace(/\.(\.\s*)+/g, ' ') // replaces ellipsis (.., ...) with space
-      .replace(/\s\./g, ' ') // replaces orphan period with space
-      .replace(/(\u0E46\s*)+/g, '\u0E46') // condenses multiple Maiyamok to one Maiyamok
-      .replace(/\u0E46/g, ' \u0E46 ') // adds a space before and after Maiyamok
-      .replace(/\s+/g, ' ') // condenses multiple spaces to one space
-      .replace(/^\.+/, '') // removes periods at the beginning of the sentence
-      .replace(/^,+/, '') // removes commas at the beginning of the sentence
-      .replace(/,+$/, '') // removes commas at the end of the sentence
-      .replace(/^:+/, '') // removes colons at the beginning of the sentence
-      .replace(/:+$/, '') // removes colons at the end of the sentence
-      .replace(/^;+/, '') // removes semicolons at the beginning of the sentence
-      .replace(/;+$/, '') // removes semicolons at the end of the sentence
-      .replace(/^\s+/, '') // removes spaces at the beginning of the sentence
-      .replace(/\s+$/, '') // removes spaces at the end of the sentence
-      .replace(/\u0E40\u0E40/g, '\u0E41') // normalizes Sara E + Sara E -> Sara Ae
-      .replace(/\u0E4d([\u0E48\u0E49\u0E4A\u0E4B]*)\u0E32/g, '$1\u0E33') // normalizes Nikhahit + Sara Aa -> Sara Am
-      .replace(/([\u0E24\u0E26])\u0E32/g, '$1\u0E45') // normalizes Ru/Lu + Sara Aa -> Ru/Lu + Lakkhangyao
+      .replace(/[\u200b\u200c]/g, '')  // remove zero-width chars (occurs in some Thai texts)
+      .replace(/\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\u0001f1e0-\u0001f1ff\u0001f300-\u0001f5ff\u0001f600-\u0001f64f\u0001f680-\u0001f6ff\u0001f700-\u0001f77f\u0001f780-\u0001f7ff\u0001f800-\u0001f8ff\u0001f900-\u0001f9ff\u0001fa00-\u0001fa6f\u0001fa70-\u0001faff\u00002702-\u000027b0\u000024c2-\u0001f251]/g, '')  // remove emoji
+      .replace(/:/g, ' : ')  // add a space before and after colon
+      .replace(/\?/g, ' ? ')  // add a space before and after question mark
+      .replace(/!/g, ' ! ')  // add a space before and after exclamation mark
+      .replace(/,/g, ' ')  // replace comma with space
+      .replace(/\.(\.\s*)+/g, ' ')  // replace ellipsis (.., ...) with space
+      .replace(/\s\./g, ' ')  // replace orphan period with space
+      .replace(/(\u0E46\s*)+/g, '\u0E46')  // condense multiple Maiyamok to one Maiyamok
+      .replace(/\u0E46/g, ' \u0E46 ')  // add a space before and after Maiyamok
+      .replace(/\s+/g, ' ')  // condense multiple spaces to one space
+      .replace(/^\.+/, '')  // remove periods at the beginning of the sentence
+      .replace(/^,+/, '')  // remove commas at the beginning of the sentence
+      .replace(/,+$/, '')  // remove commas at the end of the sentence
+      .replace(/^:+/, '')  // remove colons at the beginning of the sentence
+      .replace(/:+$/, '')  // remove colons at the end of the sentence
+      .replace(/^;+/, '')  // remove semicolons at the beginning of the sentence
+      .replace(/;+$/, '')  // remove semicolons at the end of the sentence
+      .replace(/^\s+/, '')  // remove spaces at the beginning of the sentence
+      .replace(/\s+$/, '')  // remove spaces at the end of the sentence
+      .replace(/\u0E40\u0E40/g, '\u0E41')  // normalize Sara E + Sara E -> Sara Ae
+      .replace(/\u0E4d([\u0E48\u0E49\u0E4A\u0E4B]*)\u0E32/g, '$1\u0E33')  // normalize Nikhahit + Sara Aa -> Sara Am
+      .replace(/([\u0E24\u0E26])\u0E32/g, '$1\u0E45')  // normalize Ru/Lu + Sara Aa -> Ru/Lu + Lakkhangyao
       ;
   });
 }

--- a/server/lib/cleanup/languages/th.js
+++ b/server/lib/cleanup/languages/th.js
@@ -19,7 +19,7 @@ function clean(sentences) {
   return sentences.map((sentence) => {
     return sentence
       .replace(/[\u200b\u200c]/g, '')  // removes zero-width chars (occurs in some Thai texts)
-      .replace(/[^0-9\u200b\u200c\u0e01-\u0e2e\u0e30-\u0e39\u0e40-\u0e45\u0e47-\u0e4c‘’‚;:“”\u0020\u0022\u0027\u0060\-\.]/g, '')  // allowed_symbols_regex
+      .replace(/[^\s0-9\u0e01-\u0e2e\u0e30-\u0e39\u0e40-\u0e45\u0e47-\u0e4c\-\.‚;:“”‘’\u0022\u0027\u0060!\u003f]/g, '')  // allowed_symbols_regex
       .replace(/:/g, ' : ') // add a space before and after colon
       .replace(/\?/g, ' ? ') // adds a space before and after question mark
       .replace(/!/g, ' ! ') // adds a space before and after exclamation mark

--- a/server/lib/cleanup/languages/th.js
+++ b/server/lib/cleanup/languages/th.js
@@ -23,7 +23,7 @@ function clean(sentences) {
   return sentences.map((sentence) => {
     return sentence
       .replace(/[\u200b\u200c]/g, '')  // remove zero-width chars (occurs in some Thai texts)
-      .replace(/\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\u0001f1e0-\u0001f1ff\u0001f300-\u0001f5ff\u0001f600-\u0001f64f\u0001f680-\u0001f6ff\u0001f700-\u0001f77f\u0001f780-\u0001f7ff\u0001f800-\u0001f8ff\u0001f900-\u0001f9ff\u0001fa00-\u0001fa6f\u0001fa70-\u0001faff\u00002702-\u000027b0\u000024c2-\u0001f251]/g, '')  // remove emoji
+      .replace(/\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\u{0001f1e0}-\u{0001f1ff}\u{0001f300}-\u{0001f5ff}\u{0001f600}-\u{0001f64f}\u{0001f680}-\u{0001f6ff}\u{0001f700}-\u{0001f77f}\u{0001f780}-\u{0001f7ff}\u{0001f800}-\u{0001f8ff}\u{0001f900}-\u{0001f9ff}\u{0001fa00}-\u{0001fa6f}\u{0001fa70}-\u{0001faff}\u{00002702}-\u{000027b0}\u{000024c2}-\u{0001f251}]/g, '')  // remove emoji
       .replace(/:/g, ' : ')  // add a space before and after colon
       .replace(/\?/g, ' ? ')  // add a space before and after question mark
       .replace(/!/g, ' ! ')  // add a space before and after exclamation mark

--- a/server/lib/cleanup/languages/th.js
+++ b/server/lib/cleanup/languages/th.js
@@ -29,7 +29,13 @@ function clean(sentences) {
       .replace(/(\u0E46\s*)+/g, '\u0E46') // condenses multiple Maiyamok to one Maiyamok
       .replace(/\u0E46/g, ' \u0E46 ') // adds a space before and after Maiyamok
       .replace(/\s+/g, ' ') // condenses multiple spaces to one space
-      .replace(/^\./, '') // removes periods at the beginning of the sentence
+      .replace(/^\.+/, '') // removes periods at the beginning of the sentence
+      .replace(/^,+/, '') // removes commas at the beginning of the sentence
+      .replace(/,+$/, '') // removes commas at the end of the sentence
+      .replace(/^:+/, '') // removes colons at the beginning of the sentence
+      .replace(/:+$/, '') // removes colons at the end of the sentence
+      .replace(/^;+/, '') // removes semicolons at the beginning of the sentence
+      .replace(/;+$/, '') // removes semicolons at the end of the sentence
       .replace(/^\s+/, '') // removes spaces at the beginning of the sentence
       .replace(/\s+$/, '') // removes spaces at the end of the sentence
       .replace(/\u0E40\u0E40/g, '\u0E41') // normalizes Sara E + Sara E -> Sara Ae

--- a/server/lib/cleanup/languages/th.js
+++ b/server/lib/cleanup/languages/th.js
@@ -17,13 +17,13 @@ function sortSentences(sentences) {
 // Maiyamok http://www.royin.go.th/?page_id=10427
 //
 // Emoji range from
-// https://gist.github.com/Alex-Just/e86110836f3f93fe7932290526529cd1
 // https://www.regextester.com/106421
+// https://stackoverflow.com/questions/10992921/how-to-remove-emoji-code-using-javascript
 function clean(sentences) {
   return sentences.map((sentence) => {
     return sentence
       .replace(/[\u200b\u200c]/g, '')  // remove zero-width chars (occurs in some Thai texts)
-      .replace(/\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\u{0001f1e0}-\u{0001f1ff}\u{0001f300}-\u{0001f5ff}\u{0001f600}-\u{0001f64f}\u{0001f680}-\u{0001f6ff}\u{0001f700}-\u{0001f77f}\u{0001f780}-\u{0001f7ff}\u{0001f800}-\u{0001f8ff}\u{0001f900}-\u{0001f9ff}\u{0001fa00}-\u{0001fa6f}\u{0001fa70}-\u{0001faff}\u{00002702}-\u{000027b0}\u{000024c2}-\u{0001f251}]/g, '')  // remove emoji
+      .replace(/\u00a9|\u00ae|[\u2000-\u3300]|[\u2580-\u27bf]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\ue000-\uf8ff]/g, '')  // remove emoji
       .replace(/:/g, ' : ')  // add a space before and after colon
       .replace(/\?/g, ' ? ')  // add a space before and after question mark
       .replace(/!/g, ' ! ')  // add a space before and after exclamation mark

--- a/server/lib/cleanup/languages/th.js
+++ b/server/lib/cleanup/languages/th.js
@@ -15,6 +15,10 @@ function sortSentences(sentences) {
 // question mark http://www.royin.go.th/?page_id=10418
 // exclamation mark http://www.royin.go.th/?page_id=10433
 // Maiyamok http://www.royin.go.th/?page_id=10427
+//
+// Emoji range from
+// https://gist.github.com/Alex-Just/e86110836f3f93fe7932290526529cd1
+// https://www.regextester.com/106421
 function clean(sentences) {
   return sentences.map((sentence) => {
     return sentence

--- a/server/lib/cleanup/languages/th.js
+++ b/server/lib/cleanup/languages/th.js
@@ -19,6 +19,7 @@ function clean(sentences) {
   return sentences.map((sentence) => {
     return sentence
       .replace(/[\u200b\u200c]/g, '')  // removes zero-width chars (occurs in some Thai texts)
+      .replace(/[^0-9\u200b\u200c\u0e01-\u0e2e\u0e30-\u0e39\u0e40-\u0e45\u0e47-\u0e4c‘’‚;:“”\u0020\u0022\u0027\u0060\-\.]/g, '')  // allowed_symbols_regex
       .replace(/:/g, ' : ') // add a space before and after colon
       .replace(/\?/g, ' ? ') // adds a space before and after question mark
       .replace(/!/g, ' ! ') // adds a space before and after exclamation mark

--- a/server/lib/validation/languages/th.js
+++ b/server/lib/validation/languages/th.js
@@ -44,7 +44,8 @@ const BEGIN_REGEX = /(^|\s+)[\u0E30\u0E32\u0E33\u0E45\u0E31\u0E34\u0E35\u0E36\u0
 /* eslint-disable-next-line no-misleading-character-class */
 const END_REGEX = /[\u0E40\u0E41\u0E42\u0E43\u0E44](\s+|$)/;
 
-// The following symbols are disallowed, please update here as well and not just the regex
+// The following symbols are disallowed,
+// please update here as well and not just the regex
 // to make it easier to read:
 // < > + * \ # @ ^ [ ] ( ) /
 // Paiyannoi: \u0E2F ฯ (ellipsis, abbreviation)
@@ -55,7 +56,10 @@ const END_REGEX = /[\u0E40\u0E41\u0E42\u0E43\u0E44](\s+|$)/;
 //
 // Latin characters are disallowed as well,
 // as they can introduce difficulty for pronunciation.
-const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+/;
+//
+// Anything that is NOT in Thai character range, whitespaces,
+// and allowed set of puncutations (mainly to remove emojis).
+const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+|[^0-9\u200b\u200c\u0e01-\u0e2e\u0e30-\u0e39\u0e40-\u0e45\u0e47-\u0e4c‘’‚;:“”\u0020\u0022\u0027\u0060\-\.]/;
 
 // Any words consisting of uppercase letters or uppercase letters with a period
 // inbetween are considered abbreviations or acronyms.

--- a/server/lib/validation/languages/th.js
+++ b/server/lib/validation/languages/th.js
@@ -56,7 +56,7 @@ const END_REGEX = /[\u0E40\u0E41\u0E42\u0E43\u0E44](\s+|$)/;
 // Latin characters (difficult to pronouce)
 // Emoji range from https://gist.github.com/Alex-Just/e86110836f3f93fe7932290526529cd1
 // and https://www.regextester.com/106421
-const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\u0001f1e0-\u0001f1ff\u0001f300-\u0001f5ff\u0001f600-\u0001f64f\u0001f680-\u0001f6ff\u0001f700-\u0001f77f\u0001f780-\u0001f7ff\u0001f800-\u0001f8ff\u0001f900-\u0001f9ff\u0001fa00-\u0001fa6f\u0001fa70-\u0001faff\u00002702-\u000027b0\u000024c2-\u0001f251])/;
+const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\u{0001f1e0}-\u{0001f1ff}\u{0001f300}-\u{0001f5ff}\u{0001f600}-\u{0001f64f}\u{0001f680}-\u{0001f6ff}\u{0001f700}-\u{0001f77f}\u{0001f780}-\u{0001f7ff}\u{0001f800}-\u{0001f8ff}\u{0001f900}-\u{0001f9ff}\u{0001fa00}-\u{0001fa6f}\u{0001fa70}-\u{0001faff}\u{00002702}-\u{000027b0}\u{000024c2}-\u{0001f251}])/;
 
 // Any words consisting of uppercase letters or uppercase letters with a period
 // inbetween are considered abbreviations or acronyms.

--- a/server/lib/validation/languages/th.js
+++ b/server/lib/validation/languages/th.js
@@ -54,7 +54,8 @@ const END_REGEX = /[\u0E40\u0E41\u0E42\u0E43\u0E44](\s+|$)/;
 // Angkhankhu: \u0E5A ๚ (used to mark end of section/verse)
 // Khomut: \u0E5B ๛ (used to mark end of chapter/document)
 // Latin characters (difficult to pronouce)
-// Emojis
+// Emoji range from https://gist.github.com/Alex-Just/e86110836f3f93fe7932290526529cd1
+// and https://www.regextester.com/106421
 const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\u0001f1e0-\u0001f1ff\u0001f300-\u0001f5ff\u0001f600-\u0001f64f\u0001f680-\u0001f6ff\u0001f700-\u0001f77f\u0001f780-\u0001f7ff\u0001f800-\u0001f8ff\u0001f900-\u0001f9ff\u0001fa00-\u0001fa6f\u0001fa70-\u0001faff\u00002702-\u000027b0\u000024c2-\u0001f251])/;
 
 // Any words consisting of uppercase letters or uppercase letters with a period

--- a/server/lib/validation/languages/th.js
+++ b/server/lib/validation/languages/th.js
@@ -54,9 +54,9 @@ const END_REGEX = /[\u0E40\u0E41\u0E42\u0E43\u0E44](\s+|$)/;
 // Angkhankhu: \u0E5A ๚ (used to mark end of section/verse)
 // Khomut: \u0E5B ๛ (used to mark end of chapter/document)
 // Latin characters (difficult to pronouce)
-// Emoji range from https://gist.github.com/Alex-Just/e86110836f3f93fe7932290526529cd1
-// and https://www.regextester.com/106421
-const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\u{0001f1e0}-\u{0001f1ff}\u{0001f300}-\u{0001f5ff}\u{0001f600}-\u{0001f64f}\u{0001f680}-\u{0001f6ff}\u{0001f700}-\u{0001f77f}\u{0001f780}-\u{0001f7ff}\u{0001f800}-\u{0001f8ff}\u{0001f900}-\u{0001f9ff}\u{0001fa00}-\u{0001fa6f}\u{0001fa70}-\u{0001faff}\u{00002702}-\u{000027b0}\u{000024c2}-\u{0001f251}])/;
+// Emoji range from https://www.regextester.com/106421 and
+// https://stackoverflow.com/questions/10992921/how-to-remove-emoji-code-using-javascript
+const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+|(\u00a9|\u00ae|[\u2000-\u3300]|[\u2580-\u27bf]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\ue000-\uf8ff])/;
 
 // Any words consisting of uppercase letters or uppercase letters with a period
 // inbetween are considered abbreviations or acronyms.

--- a/server/lib/validation/languages/th.js
+++ b/server/lib/validation/languages/th.js
@@ -9,8 +9,8 @@
 const MIN_LENGTH = 2;
 const MAX_LENGTH = 80;
 
-// Numbers that are not allowed in a sentence depending on the language. For
-// English this is 0-9 once or multiple times after each other.
+// Numbers that are not allowed in a sentence depending on the language.
+// For English this is 0-9 once or multiple times after each other.
 // Thai digits: \u0E50-\u0E59 (๐-๙)
 const NUMBERS_REGEX = /[0-9๐-๙]+/;
 

--- a/server/lib/validation/languages/th.js
+++ b/server/lib/validation/languages/th.js
@@ -59,7 +59,8 @@ const END_REGEX = /[\u0E40\u0E41\u0E42\u0E43\u0E44](\s+|$)/;
 //
 // Anything that is NOT in Thai character range, whitespaces,
 // and allowed set of puncutations (mainly to remove emojis).
-const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+|[^0-9\u200b\u200c\u0e01-\u0e2e\u0e30-\u0e39\u0e40-\u0e45\u0e47-\u0e4c‘’‚;:“”\u0020\u0022\u0027\u0060\-\.]/;
+// (adapted from `allowed_symbols_regex` rule in cv-sentence-extractor)
+const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+|[^\s\u200b\u200c\u0e01-\u0e2e\u0e30-\u0e39\u0e40-\u0e45\u0e47-\u0e4c\-\.‚;:“”‘’\u0022\u0027\u0060!\u003f]/;
 
 // Any words consisting of uppercase letters or uppercase letters with a period
 // inbetween are considered abbreviations or acronyms.

--- a/server/lib/validation/languages/th.js
+++ b/server/lib/validation/languages/th.js
@@ -53,14 +53,9 @@ const END_REGEX = /[\u0E40\u0E41\u0E42\u0E43\u0E44](\s+|$)/;
 // Fongman: \u0E4F ๏ (used as bullet)
 // Angkhankhu: \u0E5A ๚ (used to mark end of section/verse)
 // Khomut: \u0E5B ๛ (used to mark end of chapter/document)
-//
-// Latin characters are disallowed as well,
-// as they can introduce difficulty for pronunciation.
-//
-// Anything that is NOT in Thai character range, whitespaces,
-// and allowed set of puncutations (mainly to remove emojis).
-// (adapted from `allowed_symbols_regex` rule in cv-sentence-extractor)
-const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+|[^\s\u200b\u200c\u0e01-\u0e2e\u0e30-\u0e39\u0e40-\u0e45\u0e47-\u0e4c\-\.‚;:“”‘’\u0022\u0027\u0060!\u003f]/;
+// Latin characters (difficult to pronouce)
+// Emojis
+const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+|(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\u0001f1e0-\u0001f1ff\u0001f300-\u0001f5ff\u0001f600-\u0001f64f\u0001f680-\u0001f6ff\u0001f700-\u0001f77f\u0001f780-\u0001f7ff\u0001f800-\u0001f8ff\u0001f900-\u0001f9ff\u0001fa00-\u0001fa6f\u0001fa70-\u0001faff\u00002702-\u000027b0\u000024c2-\u0001f251])/;
 
 // Any words consisting of uppercase letters or uppercase letters with a period
 // inbetween are considered abbreviations or acronyms.


### PR DESCRIPTION
- Validation will not allow emojis
- Cleanup will remove emojis

## Background

Since mid-April 2021, Mozilla Thailand Community started to add more sentences via the Sentence Collector web interface (I believe this is a preparation towards their localization event on 25 April).

One of the thing few of the members do is exporting their own Twitter archive and add them to Sentence Collector.

@wannaphong has noticed that some of the sentences have emojis. So we need to reject or remove these emojis.