### PR TITLE
Remove U+2063 (invisible separator) from sentence

### DIFF
--- a/server/lib/cleanup/languages/th.js
+++ b/server/lib/cleanup/languages/th.js
@@ -7,7 +7,11 @@ function sortSentences(sentences) {
   return sentences.sort();
 }
 
-// Guidelines from the Office of the Royal Society
+// Remove zero-width chars and invisible separators
+// that may occur in copy-and-pasted text
+//
+// Normalize Thai punctuation using guidelines
+// from the Office of the Royal Society:
 // comma http://www.royin.go.th/?page_id=10392
 //   (in bibliography/index use case, removing comma may change the sentence's semantic,
 //   but that use case seems irrelevant here and in any case does not affect sound)
@@ -16,13 +20,13 @@ function sortSentences(sentences) {
 // exclamation mark http://www.royin.go.th/?page_id=10433
 // Maiyamok http://www.royin.go.th/?page_id=10427
 //
-// Emoji range from
+// Remove emojis, using emoji range from:
 // https://www.regextester.com/106421
 // https://stackoverflow.com/questions/10992921/how-to-remove-emoji-code-using-javascript
 function clean(sentences) {
   return sentences.map((sentence) => {
     return sentence
-      .replace(/[\u200b\u200c]/g, '')  // remove zero-width chars (occurs in some Thai texts)
+      .replace(/[\u200b\u200c\u2063]/g, '')  // remove zero-width chars (occurs in some Thai texts)
       .replace(/\u00a9|\u00ae|[\u2000-\u3300]|[\u2580-\u27bf]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\ue000-\uf8ff]/g, '')  // remove emoji
       .replace(/:/g, ' : ')  // add a space before and after colon
       .replace(/\?/g, ' ? ')  // add a space before and after question mark

--- a/server/lib/validation/languages/th.js
+++ b/server/lib/validation/languages/th.js
@@ -32,7 +32,7 @@ const NUMBERS_REGEX = /[0-9๐-๙]+/;
 // These classes of Thai characters have a specific legitimate order.
 // - Tone marks/Pinthu/Thanthakat/Nikhahit/Yamakkan can't immediately come after lead and follow vowels
 // - Tone marks/Pinthu/Thanthakat/Nikhahit/Yamakkan can't immediately come before above and below vowels
-const STRUCTURE_REGEX = /[\u0E01-\u0E4Ea-zA-Z.,\-"'?!:;]{55,}|[\u0E40\u0E41\u0E42\u0E43\u0E44]{2,}|\u0E30{2,}|[\u0E32\u0E33\u0E45]{2,}|[\u0E31\u0E34\u0E35\u0E36\u0E37\u0E4D\u0E47]{2,}|[\u0E38\u0E39]{2,}|[\u0E48\u0E49\u0E4A\u0E4B]{2,}|\u0E3A{2,}|\u0E4C{2,}|\u0E4D{2,}|\u0E4E{2,}|[\u0E40\u0E41\u0E42\u0E43\u0E44\u0E30\u0E32\u0E33\u0E45][\u0E48\u0E49\u0E4A\u0E4B\u0E3A\u0E4C\u0E4D\u0E4E]|[\u0E48\u0E49\u0E4A\u0E4B\u0E3A\u0E4C\u0E4D\u0E4E][\u0E31\u0E34\u0E35\u0E36\u0E37\u0E4D\u0E47\u0E38\u0E39]/;
+const STRUCTURE_REGEX = /[\u0E01-\u0E4Ea-zA-Z.,\-"'“”‘’\u0060?!:;]{55,}|[\u0E40\u0E41\u0E42\u0E43\u0E44]{2,}|\u0E30{2,}|[\u0E32\u0E33\u0E45]{2,}|[\u0E31\u0E34\u0E35\u0E36\u0E37\u0E4D\u0E47]{2,}|[\u0E38\u0E39]{2,}|[\u0E48\u0E49\u0E4A\u0E4B]{2,}|\u0E3A{2,}|\u0E4C{2,}|\u0E4D{2,}|\u0E4E{2,}|[\u0E40\u0E41\u0E42\u0E43\u0E44\u0E30\u0E32\u0E33\u0E45][\u0E48\u0E49\u0E4A\u0E4B\u0E3A\u0E4C\u0E4D\u0E4E]|[\u0E48\u0E49\u0E4A\u0E4B\u0E3A\u0E4C\u0E4D\u0E4E][\u0E31\u0E34\u0E35\u0E36\u0E37\u0E4D\u0E47\u0E38\u0E39]/;
 // These Thai chars cannot start the word:
 // - All vowels except lead vowels
 // - Tone marks
@@ -53,7 +53,7 @@ const END_REGEX = /[\u0E40\u0E41\u0E42\u0E43\u0E44](\s+|$)/;
 // Fongman: \u0E4F ๏ (used as bullet)
 // Angkhankhu: \u0E5A ๚ (used to mark end of section/verse)
 // Khomut: \u0E5B ๛ (used to mark end of chapter/document)
-// Latin characters (difficult to pronouce)
+// Latin characters (difficult to pronounce)
 // Emoji range from https://www.regextester.com/106421 and
 // https://stackoverflow.com/questions/10992921/how-to-remove-emoji-code-using-javascript
 const SYMBOL_REGEX = /[<>+*\\#@^[\]()/\u0E2F\u0E46\u0E4F\u0E5A\u0E5B]|[A-Za-z]+|(\u00a9|\u00ae|[\u2000-\u3300]|[\u2580-\u27bf]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[\ue000-\uf8ff])/;


### PR DESCRIPTION
- Cleanup: Remove U+2063 (invisible separator) which occurs in Thai text cut & pasted from some text editors (like MS Word and iOS Notes) - to reduce duplicated texts
- Validation: `STRUCTURE_REGEX` to prevent having “” ‘’ and ` in a long running text (of 55 or more characters)

Note: in the Sentence Extractor, the plan is to remove U+2063 as well (same as U+200b and U+200c zero-width chars)
