### PR TITLE
Basic rule file for Esperanto

### DIFF
--- a/server/lib/validation/languages/eo.js
+++ b/server/lib/validation/languages/eo.js
@@ -16,8 +16,8 @@ const INVALIDATIONS = [{
   regex: /[0-9]+/,
   error: 'Sentence should not contain numbers',
 }, {
-  regex: /[<>+*#@^[\]()/xXyYwW]/,
-  error: 'Sentence should not contain symbols or the letterss X Y or W',
+  regex: /[<>+*#@^[\]()/xXyYwWäÄöÖüÜßððÀÁÂÃÅÆÇÈÉÊËÌÍİÎÏÐÑÒÓÔÕØÙÚÛÛÝŽàáâãåæçèéêëìíîïðñòóôõøùúûýþÿāăąćċčďđēĕėęěğġģħĩīĭįıķĸĺļľŀłńņņṫšЎḃḋḟṁṗṡẁẃẅẛỳαβΓγΔδεζηΘθικΛλμνΞξΠπρΣσςτșếōůūŁşşǐżőňựňžịŌŏČŠřś]/,
+  error: 'Sentence should not contain symbols or the letterss X Y or W or any letter that is not part of the EO alphabet',
 }, {
   // Any words consisting of uppercase letters or uppercase letters with a period
   // inbetween are considered abbreviations or acronyms.

--- a/server/lib/validation/languages/eo.js
+++ b/server/lib/validation/languages/eo.js
@@ -17,7 +17,7 @@ const INVALIDATIONS = [{
   error: 'Sentence should not contain numbers',
 }, {
   regex: /[<>+*#@^[\]()/wWqQxXyYäÄöÖüÜßððÀÁÂÃÅÆÇÈÉÊËÌÍİÎÏÐÑÒÓÔÕØÙÚÛÛÝŽàáâãåæçèéêëìíîïðñòóôõøùúûýþÿāăąćċčďđēĕėęěğġģħĩīĭįıķĸĺļľŀłńņņṫšЎḃḋḟṁṗṡẁẃẅẛỳαβΓγΔδεζηΘθικΛλμνΞξΠπρΣσςτșếōůūŁşşǐżőňựňžịŌŏČŠřś]/,
-  error: 'Sentence should not contain symbols or the letterss X Y or W or any letter that is not part of the EO alphabet',
+  error: 'Sentence should not contain symbols, the letterss W, Q, X or Y or any letter that is not part of the EO alphabet',
 }, {
   // Any words consisting of uppercase letters or uppercase letters with a period
   // inbetween are considered abbreviations or acronyms.

--- a/server/lib/validation/languages/eo.js
+++ b/server/lib/validation/languages/eo.js
@@ -16,7 +16,7 @@ const INVALIDATIONS = [{
   regex: /[0-9]+/,
   error: 'Sentence should not contain numbers',
 }, {
-  regex: /[<>+*#@^[\]()/xXyYwWäÄöÖüÜßððÀÁÂÃÅÆÇÈÉÊËÌÍİÎÏÐÑÒÓÔÕØÙÚÛÛÝŽàáâãåæçèéêëìíîïðñòóôõøùúûýþÿāăąćċčďđēĕėęěğġģħĩīĭįıķĸĺļľŀłńņņṫšЎḃḋḟṁṗṡẁẃẅẛỳαβΓγΔδεζηΘθικΛλμνΞξΠπρΣσςτșếōůūŁşşǐżőňựňžịŌŏČŠřś]/,
+  regex: /[<>+*#@^[\]()/wWqQxXyYäÄöÖüÜßððÀÁÂÃÅÆÇÈÉÊËÌÍİÎÏÐÑÒÓÔÕØÙÚÛÛÝŽàáâãåæçèéêëìíîïðñòóôõøùúûýþÿāăąćċčďđēĕėęěğġģħĩīĭįıķĸĺļľŀłńņņṫšЎḃḋḟṁṗṡẁẃẅẛỳαβΓγΔδεζηΘθικΛλμνΞξΠπρΣσςτșếōůūŁşşǐżőňựňžịŌŏČŠřś]/,
   error: 'Sentence should not contain symbols or the letterss X Y or W or any letter that is not part of the EO alphabet',
 }, {
   // Any words consisting of uppercase letters or uppercase letters with a period

--- a/server/lib/validation/languages/eo.js
+++ b/server/lib/validation/languages/eo.js
@@ -1,0 +1,32 @@
+const tokenizeWords = require('talisman/tokenizers/words');
+
+// Minimum of words that qualify as a sentence.
+const MIN_WORDS = 1;
+
+// Maximum of words allowed per sentence to keep recordings in a manageable duration.
+const MAX_WORDS = 14;
+
+const INVALIDATIONS = [{
+  fn: (sentence) => {
+    const words = tokenizeWords(sentence);
+    return words.length < MIN_WORDS || words.length > MAX_WORDS;
+  },
+  error: `Number of words must be between ${MIN_WORDS} and ${MAX_WORDS} (inclusive)`,
+}, {
+  regex: /[0-9]+/,
+  error: 'Sentence should not contain numbers',
+}, {
+  regex: /[<>+*#@^[\]()/]/,
+  error: 'Sentence should not contain symbols',
+}, {
+  // Any words consisting of uppercase letters or uppercase letters with a period
+  // inbetween are considered abbreviations or acronyms.
+  // This currently also matches fooBAR but we most probably don't want that either
+  // as users wouldn't know how to pronounce the uppercase letters.
+  regex: /[A-Z]{2,}|[A-Z]+\.*[A-Z]+/,
+  error: 'Sentence should not contain abbreviations',
+}];
+
+module.exports = {
+  INVALIDATIONS,
+};

--- a/server/lib/validation/languages/eo.js
+++ b/server/lib/validation/languages/eo.js
@@ -16,8 +16,8 @@ const INVALIDATIONS = [{
   regex: /[0-9]+/,
   error: 'Sentence should not contain numbers',
 }, {
-  regex: /[<>+*#@^[\]()/]/,
-  error: 'Sentence should not contain symbols',
+  regex: /[<>+*#@^[\]()/xXyYwW]/,
+  error: 'Sentence should not contain symbols or the letterss X Y or W',
 }, {
   // Any words consisting of uppercase letters or uppercase letters with a period
   // inbetween are considered abbreviations or acronyms.


### PR DESCRIPTION
This is a basic rule file for Esperanto based on the english rule file. The only thing I changed is that I added more forbidden letters. Most important are the letters W Q X and Y that are not part of the Esperanto alphabet. But I also added many other letters that were often a problem during the Wiki Extraction. 