### PR TITLE
fix: prevent horizontal scrollbar from flickering during swipe

### DIFF
--- a/web/css/root.css
+++ b/web/css/root.css
@@ -33,6 +33,8 @@ html {
 
 body {
   margin: 0;
+  /** Prevent the "tinder-card" movement from temporarily trigger a horizontal scrollbar */
+  overflow-x: hidden;
 }
 
 input, textarea, button, select {


### PR DESCRIPTION
A minor issue, but when reviewing sentences the TinderCard animation will make the horizontal (and sometimes the vertical scrollbar) appear. This is quite jarring to me.

The TinderCard library recommend using `overflow: hidden` outright, but we need to allow vertical scrolling. I couldn't find a relatively simple solution for the vertical scrollbar.

But testing most pages I could not find any which need horizontal scrolling - so using `overflow-x: hidden` should be ok atm. Though it feels a bit dirty to apply the rule to *all* pages - but making it only apply to the review page isn't straight forward (applying it to the form-div doesn't work due to the padding)

Personally I would prefer no animation on desktop, but that's another matter. (and easily solvable using a user-stylesheet)

```css
/* https://commonvoice.mozilla.org/sentence-collector/#/review */
body {
    overflow: hidden;
}

section.cards-container > div {
    transition: none !important;
}
```