### PR TITLE
update docker image tag for main w/ts for flux

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,18 +12,18 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: docker-tags
+      - name: docker-tags
         id: tags
         run: |
           DOCKER_IMAGE=mozilla/sentencecollector
           VERSION=noop
+          TAG_TS=$(date +%s)
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
             if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=main-${GITHUB_SHA::8}
+              VERSION=main-${GITHUB_SHA::8}-${TAG_TS}
             fi
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2206

What this PR does:
* Adds a timestamp to the end of the GitHub Actions-generated Docker image's tag (for main branch builds) 
* Does not touch the Docker images for anything else

Why this PR:
* adding the timestamp to git commit hash based images helps the fluxcd upgrades track latest docker image tags
* we're updating fluxcd (what pulls newer docker images, based on tags, to stage or prod deployments) while moving it from github.com/mozilla-it/voice-infra to github.com/common-voice/voice-infra

PR: for @phirework & @jzinner primarily