### PR TITLE
fix: do not use locale prefixed URLs for login/logout

### DIFF
--- a/web/src/app.tsx
+++ b/web/src/app.tsx
@@ -33,21 +33,6 @@ export default function App({ history }: { history: History }) {
         {/* Redirects to EN as default language */}
         <Route exact path="/" render={() => <Redirect to={{ pathname: '/en' }} />} />
         <Route exact path="/how-to" render={() => <Redirect to={{ pathname: '/en/how-to' }} />} />
-        <Route
-          exact
-          path="/login-failure"
-          render={() => <Redirect to={{ pathname: '/en/login-failure' }} />}
-        />
-        <Route
-          exact
-          path="/login-success"
-          render={() => <Redirect to={{ pathname: '/en/login-success' }} />}
-        />
-        <Route
-          exact
-          path="/logout-success"
-          render={() => <Redirect to={{ pathname: '/en/logout-success' }} />}
-        />
         <Route exact path="/profile" render={() => <Redirect to={{ pathname: '/en/profile' }} />} />
         <Route exact path="/add" render={() => <Redirect to={{ pathname: '/en/add' }} />} />
         <Route exact path="/review" render={() => <Redirect to={{ pathname: '/en/review' }} />} />
@@ -58,6 +43,19 @@ export default function App({ history }: { history: History }) {
         <Route path="/rejected" render={() => <Redirect to={{ pathname: '/en/rejected' }} />} />
         <Route path="/sentences" render={() => <Redirect to={{ pathname: '/en/sentences' }} />} />
         <Route path="/stats" render={() => <Redirect to={{ pathname: '/en/stats' }} />} />
+
+        {/* Routes without integrated locale parameter */}
+        <Route
+          exact
+          path="/login-failure"
+          render={() => (
+            <PageContainer>
+              <LoginFailure />
+            </PageContainer>
+          )}
+        />
+        <Route exact path="/login-success" render={() => <LoginSuccess />} />
+        <Route exact path="/logout-success" render={() => <LogoutSuccess />} />
 
         {/* Routes with integrated locale parameter */}
         <Route
@@ -75,33 +73,6 @@ export default function App({ history }: { history: History }) {
           render={() => (
             <Page>
               <HowTo />
-            </Page>
-          )}
-        />
-        <Route
-          exact
-          path="/:locale/login-failure"
-          render={() => (
-            <Page>
-              <LoginFailure />
-            </Page>
-          )}
-        />
-        <Route
-          exact
-          path="/:locale/login-success"
-          render={() => (
-            <Page>
-              <LoginSuccess />
-            </Page>
-          )}
-        />
-        <Route
-          exact
-          path="/:locale/logout-success"
-          render={() => (
-            <Page>
-              <LogoutSuccess />
             </Page>
           )}
         />


### PR DESCRIPTION
We should not use locale prefixed URLs for login and logout. The redirect will be to EN anyway, and we do not have any localizeable content in the success cases anyway, those are just redirects.

For the failed login case, we don't need a param, as we can negotiate the language appropriately when loading the component. Additionally I wrapped the Login Failure component into the PageContainer, so we don't lose the menu. This was a bug I recently introduced.

![image](https://user-images.githubusercontent.com/330324/139531426-1667cb09-5c3b-4caa-9b53-5272a9cf9bb1.png)
