### PR TITLE
chore: adjust export to also export Sentence Collector FTL source file to CV (fixes #525)

### DIFF
--- a/.github/workflows/export.yaml
+++ b/.github/workflows/export.yaml
@@ -35,20 +35,29 @@ jobs:
         run: cd cv && NODE_ENV=development npm install && rm package-lock.json
       - name: Install SC dependencies
         run: npm ci
+      - name: Set Git Author
+        run: git config --global user.name "Sentence Collector Exporter"
+      - name: Set Git Email
+        run: git config --global user.email "mkohler+cvexport@picobudget.com"
+
       - name: Run Export
         run: env API_BASE_URL=${{secrets.SC_EXPORT_BASE_URL}} COMMON_VOICE_PATH=cv/ node scripts/exporter.js
       - name: Run CV Update Locales Script
         run: cd cv && npm run import-locales
       - name: CV Changes
         run: cd cv && git diff --numstat
-      - name: Set Git Author
-        run: git config --global user.name "Sentence Collector Exporter"
-      - name: Set Git Email
-        run: git config --global user.email "mkohler+cvexport@picobudget.com"
       - name: Format Changes
         run: cd cv && git add -A && npx pretty-quick --staged
       - name: Commit CV Changes
         run: cd cv && git commit -m "Automatic Sentence Collector Export + Update Locales if necessary"
+
+      - name: Prepare locale FTL source file (EN)
+        run: env COMMON_VOICE_PATH=cv/ node scripts/prepare-source-strings-export.js
+      - name: Add CV Changes
+        run: cd cv && git add web/locales/en/messages.ftl || true
+      - name: Commit CV Changes
+        run: cd cv && git commit -m "Export Sentence Collector source strings" || true
+
       - name: Push to CV
         run: cd cv && git push origin ${{secrets.COMMON_VOICE_BRANCH}}
 

--- a/scripts/export-source-strings.js
+++ b/scripts/export-source-strings.js
@@ -1,0 +1,47 @@
+// We are handling translations within the Common Voice repository.
+// Therefore we export the source translation strings on every export
+// and then they get translated in the Common Voice Pontoon infrastructure.
+// Translated strings are pulled back in when building Sentence Collector
+// on deployments.
+
+const {
+  readFile,
+  writeFile,
+} = require('fs/promises');
+const path = require('path');
+
+const {
+  COMMON_VOICE_PATH,
+} = process.env;
+
+if (!COMMON_VOICE_PATH) {
+  throw new Error('COMMON_VOICE_PATH is required!');
+}
+
+const sentenceCollectorFTLPath = path.resolve(__dirname, '..', 'web', 'locales', 'en', 'messages.ftl');
+const commonVoiceFTLPath = path.resolve(COMMON_VOICE_PATH, 'web', 'locales', 'en', 'messages.ftl');
+
+const PREAMBLE = '# [SentenceCollector]';
+const POSTAMBLE = '# [/SentenceCollector]';
+
+(async () => {
+  await appendSentenceCollectorStrings();
+})();
+
+async function appendSentenceCollectorStrings() {
+  console.log('Cleaning Sentence Collector entries from: ', commonVoiceFTLPath);
+  const cvFTLContent = await readFile(commonVoiceFTLPath, 'utf8');
+  const cvLines = cvFTLContent.split('\n');
+  const preambleIndex = cvLines.indexOf(PREAMBLE);
+  const postambleIndex = cvLines.indexOf(POSTAMBLE);
+
+  console.log('Getting Sentence Collector entries from: ', sentenceCollectorFTLPath);
+  const scFTLContent = await readFile(sentenceCollectorFTLPath, 'utf8');
+  const scFTLLines = scFTLContent.split('\n').filter((line) => line !== '' && !line.startsWith('#'));
+
+  console.log('Preparing combined file...');
+  cvLines.splice(preambleIndex + 1, postambleIndex - preambleIndex - 1, ...scFTLLines);
+
+  console.log('Writing new file to: ', commonVoiceFTLPath);
+  await writeFile(commonVoiceFTLPath, cvLines.join('\n'));
+}


### PR DESCRIPTION
This will export the EN source FTL file to CV on every automatic export. These strings then get translated in the CV Pontoon infrastructure. This makes sure we don't need an additional project on Pontoon and can handle everything within the Common Voice project.

Do not merge this until the PR on the Common Voice side has been merged.