### PR TITLE
Better integration into Pontoon

### DIFF
--- a/scripts/export-source-strings.js
+++ b/scripts/export-source-strings.js
@@ -37,7 +37,7 @@ async function appendSentenceCollectorStrings() {
 
   console.log('Getting Sentence Collector entries from: ', sentenceCollectorFTLPath);
   const scFTLContent = await readFile(sentenceCollectorFTLPath, 'utf8');
-  const scFTLLines = scFTLContent.split('\n').filter((line) => line !== '' && !line.startsWith('#'));
+  const scFTLLines = scFTLContent.split('\n');
 
   console.log('Preparing combined file...');
   cvLines.splice(preambleIndex + 1, postambleIndex - preambleIndex - 1, ...scFTLLines);

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -225,6 +225,7 @@ sc-review-form-source = Source: { $sentenceSource }
 sc-review-form-button-reject = Reject
 sc-review-form-button-skip = Skip
 sc-review-form-button-approve = Approve
+# Keyboard shortcut keys are currently not localizeable, please use Y/N/S for now
 sc-review-form-keyboard-usage = You can also use Keyboard Shortcuts: Y to Approve, N to Reject, S to Skip
 sc-review-form-button-submit =
     .submitText = Finish Review

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -1,7 +1,4 @@
-###
-### HEADER/FOOTER MENUS & LOGIN/LOGOUT
-###
-
+## HEADER/FOOTER
 sc-header-home = Home
 sc-header-how-to = How-to
 sc-header-add = Add
@@ -10,7 +7,6 @@ sc-header-rejected = Rejected Sentences
 sc-header-my = My Sentences
 sc-header-statistics = Statistics
 sc-header-profile = Profile
-
 sc-footer-discourse = Discourse
 sc-footer-report-bugs = Report Bugs
 sc-footer-translate = Translate this page
@@ -18,14 +14,10 @@ sc-footer-report-copyright = Report copyright issues
 sc-footer-privacy = Privacy
 sc-footer-terms = Terms
 sc-footer-cookies = Cookies
-
 sc-login-signup-button = Login / Signup
 sc-logout-button = Logout
 
-###
-### PAGES
-###
-
+## HOME
 sc-home-title = Welcome to the Common Voice Sentence Collector
 sc-home-intro = The Sentence Collector is part of <commonVoiceLink>Common Voice</commonVoiceLink>. It allows contributors to collect and validate sentences created by the community. You can use this tool also to import and clean-up small-to-medium-sized public domain corpus you have found or collected. All sentences need to be Public Domain. Approved sentences are exported every week to the Common Voice repository and are released on the Common Voice website on every new deployment.
 sc-home-collect-title = Collect sentences
@@ -33,6 +25,7 @@ sc-home-collect-text = Help us by writing or collecting Public Domain sentences.
 sc-home-review-title = Review sentences
 sc-home-review-text = Help us by reviewing sentences for correctness according to the guidelines.
 
+## HOW-TO
 sc-howto-title = How to
 sc-howto-addlang-title = Adding languages to work with
 sc-howto-addlang-text = Once logged in you can select your languages from the profile section.
@@ -68,6 +61,7 @@ sc-howto-findpd-subtitle-2 = Partner with local organizations or individuals
 sc-howto-findpd-partner-1 = There are a lot of public organizations that might want to collaborate and already have a lot of texts they can donate as public domain. Reach out to local Universities, Governments and open source organizations to talk about the project and ask for their help.
 sc-howto-findpd-partner-2 = Expert linguists can also help, try to reach out to local linguistic Universities (both teachers and students) and see if they can help to gather a diverse set of sound-diverse sentences in your language.
 
+## MY SENTENCES
 sc-my-title = My Sentences
 sc-my-description = This page gives you an overview of all your submitted sentences. You may also delete already submitted sentences if needed by marking the checkbox next to it and clicking on &quot;Delete selected sentences&quot; at the bottom. Please only remove sentences if absolutely necessary, for example if you noticed after the fact that a sentence is copyright protected.
 sc-my-loading = Loading your sentences…
@@ -79,25 +73,20 @@ sc-my-delete = Delete selected sentences
 sc-my-deleting = Deleting selected sentences…
 sc-my-err-failed-delete = Failed to delete selected sentences… Please try again!
 
-sc-profile-title = Profile: { $username }
-
+## REJECTED
 sc-rejected-title = Rejected Sentences
 sc-rejected-loading = Loading rejected sentences…
 sc-rejected-err-fetching = Error while fetching rejected sentences. Please try again.
 sc-rejected-none-found = No rejected sentences found!
 
-sc-review-lang-not-selected = You have not selected any languages. Please go to your <profileLink>Profile</profileLink> to select languages.
-sc-review-title = Review Sentences
-sc-review-loading = Loading sentences…
-sc-review-select-language = Please select a language to review sentences.
-sc-review-no-sentences = No sentences to review. <addLink>Add more sentences now!</addLink>
-
+## STATS
 sc-stats-title = Statistics
 sc-stats-last-update = Last Update: { $lastUpdate }
 sc-stats-last-update-never = Last Update: never
 sc-stats-updating = Updating…
 sc-stats-summary = The Common Voice Sentence Collector has collected { $sentenceCount } sentences in { $languageCount } languages!
 
+## ADD
 sc-submit-err-select-lang = Please select a language.
 sc-submit-err-add-sentences = Please add sentences.
 sc-submit-err-add-source = Please add a source.
@@ -119,14 +108,10 @@ sc-submit-button =
 sc-submit-filtered = Filtered sentences due to requirements failing (please submit fixed versions as new sentences):
 sc-submit-guidelines = Please check the <howToLink>guidelines</howToLink>.
 
-###
-### OTHER NON-PAGE / SUB-COMPONENTS
-###
-
+## ADD LANGUAGE
 sc-add-lang-could-not-add = Could not add language
 sc-add-lang-sec-label = Add a language you want to contribute to
 sc-add-lang-sec-button = Add Language
-
 sc-add-err-unexpected = Unexpected response returned from server
 sc-add-result =
     {$duplicates ->
@@ -142,6 +127,7 @@ sc-add-err-failed =
     }
 sc-add-err-submission = Submission Error
 
+## ADD SENTENCES CONFIRMATION
 sc-confirm-are-you-sure =
     .message = Sentences not submitted, are you sure you want to leave?
 sc-confirm-sentences-title = Confirm New Sentences
@@ -168,6 +154,7 @@ sc-confirm-unreviewed = { $countOfUnreviewed } sentences are unreviewed. If you 
 sc-confirm-button-text = Confirm
 sc-confirm-uploading = Sentences are being uploaded. This can take several minutes depending on the number of sentences added. Please do not close this website.
 
+## LANGUAGE INFO
 sc-lang-info-total =
     {$totalSentences ->
         [0] No total sentences.
@@ -201,9 +188,12 @@ sc-lang-info-rejected =
         *[other] {$rejectedSentences} rejected sentences.
     }
 
+## LOGIN
 sc-login-err-failed = Login failed
 sc-login-err-try-again = Please try again.
 
+## PROFILE
+sc-profile-title = Profile: { $username }
 sc-personal-err-lang-not-found = Could not remove language: language not found
 sc-personal-err-remove = Could not remove language
 sc-personal-your-languages = Your languages:
@@ -211,6 +201,7 @@ sc-personal-remove-button = remove
 sc-personal-added-by-you = { $sentences } added by you
 sc-personal-not-added = You have not added any languages yet.
 
+## REVIEW CRITERIA
 sc-criteria-modal = ⓘ Review Criteria
 sc-criteria-title = Review Criteria
 sc-criteria-make-sure = Make sure the sentence meets the following criteria:
@@ -221,6 +212,12 @@ sc-criteria-item-4 = If the sentence meets the criteria, click the &quot;Approve
 sc-criteria-item-5 = If the sentence does not meet the above criteria, click the &quot;Reject&quot; button on the right. If you are unsure about the sentence, you may also skip it and move on to the next one.
 sc-criteria-item-6 = If you run out of sentences to review, please help us collect more sentences!
 
+## REVIEW
+sc-review-lang-not-selected = You have not selected any languages. Please go to your <profileLink>Profile</profileLink> to select languages.
+sc-review-title = Review Sentences
+sc-review-loading = Loading sentences…
+sc-review-select-language = Please select a language to review sentences.
+sc-review-no-sentences = No sentences to review. <addLink>Add more sentences now!</addLink>
 sc-review-form-prompt =
     .message = Reviewed sentences not submitted, are sure?
 sc-review-form-usage = Swipe right to approve the sentence. Swipe left to reject it. Swipe up to skip it. <strong>Do not forget to submit your review!</strong>
@@ -238,9 +235,9 @@ sc-review-form-reviewed-message =
         *[other] { $sentences } sentences reviewed. Thank you!
     }
 sc-review-form-review-failure = Review could not be saved. Please try again later.
-
 sc-review-link = Review
 
+## SETTINGS
 sc-settings-title = Settings
 sc-settings-reset-skipped = Reset skipped sentences
 sc-settings-skipped-decription = You previously skipped sentences while reviewing. Resetting skipped sentences will show all skipped sentences again. This is independent of the language.


### PR DESCRIPTION
This groups the strings a bit better and adds group titles to them. This way Pontoon will show these correctly, and not taking the overarching group from CV. Additionally to that this gets rid of the comment on `sc-header-home` as it took the overall section title in the CV FTL file as a comment for that string. By adding a group title it won't happen anymore.

And lastly, this adds a localization note for the keyboard shortcut keys not being localizeable for now.