### PR TITLE
chore: use default validator and translate its error message (fixes #494)

### DIFF
--- a/server/lib/validation/index.js
+++ b/server/lib/validation/index.js
@@ -1,3 +1,4 @@
+const defaultValidator = require('./languages/default');
 const bas = require('./languages/bas');
 const en = require('./languages/en');
 const eo = require('./languages/eo');
@@ -23,9 +24,6 @@ const VALIDATORS = {
   ur,
   or,
 };
-
-const DEFAULT_VALIDATOR_LANGUAGE = 'en';
-const DEFAULT_VALIDATOR = VALIDATORS[DEFAULT_VALIDATOR_LANGUAGE];
 
 module.exports = {
   validateSentences,
@@ -87,5 +85,5 @@ function validateSentence(validator, sentence) {
 }
 
 function getValidatorFor(language) {
-  return VALIDATORS[language] || DEFAULT_VALIDATOR;
+  return VALIDATORS[language] || defaultValidator;
 }

--- a/server/lib/validation/languages/default.js
+++ b/server/lib/validation/languages/default.js
@@ -1,0 +1,34 @@
+const tokenizeWords = require('talisman/tokenizers/words');
+
+const TRANSLATION_KEY_PREFIX = 'TRANSLATION_KEY:';
+
+// Minimum of words that qualify as a sentence.
+const MIN_WORDS = 1;
+
+// Maximum of words allowed per sentence to keep recordings in a manageable duration.
+const MAX_WORDS = 14;
+
+const INVALIDATIONS = [{
+  fn: (sentence) => {
+    const words = tokenizeWords(sentence);
+    return words.length < MIN_WORDS || words.length > MAX_WORDS;
+  },
+  error: `${TRANSLATION_KEY_PREFIX}sc-validation-number-of-words`,
+}, {
+  regex: /[0-9]+/,
+  error: `${TRANSLATION_KEY_PREFIX}sc-validation-no-numbers`,
+}, {
+  regex: /[<>+*#@^[\]()/]/,
+  error: `${TRANSLATION_KEY_PREFIX}sc-validation-no-symbols`,
+}, {
+  // Any words consisting of uppercase letters or uppercase letters with a period
+  // in-between are considered abbreviations or acronyms.
+  // This currently also matches fooBAR but we most probably don't want that either
+  // as users wouldn't know how to pronounce the uppercase letters.
+  regex: /[A-Z]{2,}|[A-Z]+\.*[A-Z]+/,
+  error: `${TRANSLATION_KEY_PREFIX}sc-validation-no-abbreviations`,
+}];
+
+module.exports = {
+  INVALIDATIONS,
+};

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -283,3 +283,9 @@ sc-settings-reset-skipped = Reset skipped sentences
 sc-settings-skipped-decription = You previously skipped sentences while reviewing. Resetting skipped sentences will show all skipped sentences again. This is independent of the language.
 sc-settings-show-all-button = Show all skipped sentences again
 sc-settings-failed = Could not change settings. Please try again.
+
+# VALIDATION
+sc-validation-number-of-words = Sentence must contain between 1 and 14 (inclusive) words
+sc-validation-no-numbers = Sentence should not contain numbers
+sc-validation-no-symbols = Sentence should not contain symbols
+sc-validation-no-abbreviations = Sentence should not contain abbreviations

--- a/web/src/components/submit-form.tsx
+++ b/web/src/components/submit-form.tsx
@@ -10,6 +10,7 @@ import SubmitButton from './submit-button';
 import { Prompt } from './prompt';
 
 const SPLIT_ON = '\n';
+const TRANSLATION_KEY_PREFIX = 'TRANSLATION_KEY:';
 
 function parseSentences(sentenceText: string): string[] {
   const sentences = sentenceText
@@ -220,14 +221,22 @@ export default function SubmitForm({
             <p></p>
           </Localized>
 
-          {Object.keys(sentenceSubmissionFailures).map((filterKey) => (
-            <React.Fragment key={'fragment-' + filterKey}>
-              <h3 key="{filterKey}">{filterKey}</h3>
-              {sentenceSubmissionFailures[filterKey].map((filteredSentence) => (
-                <Sentence key={filteredSentence}>{filteredSentence}</Sentence>
-              ))}
-            </React.Fragment>
-          ))}
+          {Object.keys(sentenceSubmissionFailures).map((filterKey) => {
+            const title = filterKey.startsWith(TRANSLATION_KEY_PREFIX) ? (
+              <Localized id={filterKey.replace(TRANSLATION_KEY_PREFIX, '')}></Localized>
+            ) : (
+              filterKey
+            );
+
+            return (
+              <React.Fragment key={'fragment-' + filterKey}>
+                <h3 key="{filterKey}">{title}</h3>
+                {sentenceSubmissionFailures[filterKey].map((filteredSentence) => (
+                  <Sentence key={filteredSentence}>{filteredSentence}</Sentence>
+                ))}
+              </React.Fragment>
+            );
+          })}
         </section>
       )}
     </React.Fragment>


### PR DESCRIPTION
This adds a default validator in case there is no language specific validator. Until now we've used English, but as we want to translate the generic messages I have created a default validator. This validator has translation keys as error message, which then gets transformed into a localized string in the frontend. For language specific validators we can still use hard coded error messages.