### PR TITLE
feat: add UI language selector to profile (fixes #533)

### DIFF
--- a/web/css/profile.css
+++ b/web/css/profile.css
@@ -12,3 +12,7 @@ button.remove-lang:active {
   background-color: transparent;
   color: inherit;
 }
+
+.settings-section {
+  margin-bottom: 30px;
+}

--- a/web/css/root.css
+++ b/web/css/root.css
@@ -10,7 +10,9 @@
   --deactive-color: #d7d7db;
   --grey-color: #d7d7db;
   --dark-grey-color: #5e5c5b;
-  --warning-color: #ff4f5e;
+  --error-color: #ff4f5e;
+  --warning-border-color: #ffff00;
+  --warning-background-color: #ffffb9;
   --review-selected-color: #000000;
   --review-unselected-color: #ffffff;
   --base-font-size: 19px;
@@ -189,7 +191,7 @@ form button:not(.standalone) {
 
 .form-error {
   line-height: 1rem;
-  color: var(--warning-color);
+  color: var(--error-color);
   text-align: center;
   font-weight: 600;
 }
@@ -213,4 +215,11 @@ form button:not(.standalone) {
 
 .small {
   font-size: 0.7rem;
+}
+
+.warning-box {
+  margin: 1.5rem 0;
+  padding: 1rem;
+  border: 2px solid var(--warning-border-color);
+  background-color: var(--warning-background-color);
 }

--- a/web/locales/en/messages.ftl
+++ b/web/locales/en/messages.ftl
@@ -280,6 +280,8 @@ sc-review-link = Review
 
 ## SETTINGS
 sc-settings-title = Settings
+sc-settings-ui-language = Interface Language
+sc-settings-language-translated-warning = The pages for this language might not be fully translated. You can help out with translation <pontoonLinkLink>on Pontoon</pontoonLinkLink>.
 sc-settings-reset-skipped = Reset skipped sentences
 sc-settings-skipped-decription = You previously skipped sentences while reviewing. Resetting skipped sentences will show all skipped sentences again. This is independent of the language.
 sc-settings-show-all-button = Show all skipped sentences again

--- a/web/src/components/language-selector.tsx
+++ b/web/src/components/language-selector.tsx
@@ -8,7 +8,7 @@ import '../../css/language-selector.css';
 const ENGLISH_CODE = 'en';
 
 type LanguageSelectorProps = {
-  labelText: string;
+  labelText?: string;
   disabled?: boolean;
   selected?: string;
   onChange: (value: string) => void;
@@ -18,9 +18,11 @@ type LanguageSelectorProps = {
 
 const LanguageSelector = (props: LanguageSelectorProps) => (
   <React.Fragment>
-    <label className="language-selector-label" htmlFor="language-selector">
-      {props.labelText}
-    </label>
+    {props.labelText && (
+      <label className="language-selector-label" htmlFor="language-selector">
+        {props.labelText}
+      </label>
+    )}
     <select
       onChange={(event) => props.onChange && props.onChange(event.target.value)}
       disabled={props.disabled}

--- a/web/src/components/profile/settings.test.tsx
+++ b/web/src/components/profile/settings.test.tsx
@@ -19,6 +19,8 @@ beforeEach(() => {
   (redux.useSelector as jest.Mock).mockImplementation(() => ({
     showErrorMessage: false,
     skippedSentences: [1],
+    currentUiLanguage: 'en',
+    allLanguages: [],
   }));
 });
 

--- a/web/src/components/profile/settings.tsx
+++ b/web/src/components/profile/settings.tsx
@@ -9,6 +9,8 @@ import type { RootState } from '../../types';
 
 import LanguageSelector from '../language-selector';
 
+const CV_TRANSLATED_LOCALES = cvTranslatedLocales;
+
 export default function Settings() {
   const { allLanguages = [], currentUILocale } = useSelector((state: RootState) => state.languages);
   const { skippedSentences } = useSelector((state: RootState) => state.sentences);
@@ -31,7 +33,7 @@ export default function Settings() {
   };
 
   useEffect(() => {
-    const possiblyUntranslated = !cvTranslatedLocales.includes(currentUILocale);
+    const possiblyUntranslated = !CV_TRANSLATED_LOCALES.includes(currentUILocale);
     setShowTranslatedWarning(possiblyUntranslated);
   }, [currentUILocale]);
 

--- a/web/src/components/profile/settings.tsx
+++ b/web/src/components/profile/settings.tsx
@@ -1,14 +1,21 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { Localized } from '@fluent/react';
 
+import cvTranslatedLocales from '../../../../locales/translated.json';
 import { resetSkippedSentences } from '../../actions/sentences';
 import type { RootState } from '../../types';
 
+import LanguageSelector from '../language-selector';
+
 export default function Settings() {
+  const { allLanguages = [], currentUILocale } = useSelector((state: RootState) => state.languages);
   const { skippedSentences } = useSelector((state: RootState) => state.sentences);
   const { showErrorMessage } = useSelector((state: RootState) => state.settings);
+  const [showTranslatedWarning, setShowTranslatedWarning] = useState(false);
   const dispatch = useDispatch();
+  const history = useHistory();
 
   const resetSkipped = (event: React.MouseEvent) => {
     event.preventDefault();
@@ -18,6 +25,15 @@ export default function Settings() {
   if (!skippedSentences || skippedSentences.length === 0) {
     return null;
   }
+
+  const onLanguageSelect = (locale: string) => {
+    history.push(`/${locale}/profile`);
+  };
+
+  useEffect(() => {
+    const possiblyUntranslated = !cvTranslatedLocales.includes(currentUILocale);
+    setShowTranslatedWarning(possiblyUntranslated);
+  }, [currentUILocale]);
 
   return (
     <section>
@@ -32,15 +48,44 @@ export default function Settings() {
       )}
 
       <section>
-        <Localized id="sc-settings-reset-skipped">
-          <h3></h3>
-        </Localized>
-        <Localized id="sc-settings-skipped-decription">
-          <p></p>
-        </Localized>
-        <button className="standalone" onClick={resetSkipped}>
-          <Localized id="sc-settings-show-all-button" />
-        </button>
+        <section className="settings-section">
+          <Localized id="sc-settings-ui-language">
+            <h3></h3>
+          </Localized>
+          <LanguageSelector
+            selected={currentUILocale}
+            languages={allLanguages}
+            onChange={onLanguageSelect}
+          />
+          {showTranslatedWarning && (
+            <Localized
+              id="sc-settings-language-translated-warning"
+              elems={{
+                pontoonLinkLink: (
+                  <a
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={`https://pontoon.mozilla.org/${currentUILocale}/common-voice/`}
+                  />
+                ),
+              }}
+            >
+              <div className="warning-box"></div>
+            </Localized>
+          )}
+        </section>
+
+        <section className="settings-section">
+          <Localized id="sc-settings-reset-skipped">
+            <h3></h3>
+          </Localized>
+          <Localized id="sc-settings-skipped-decription">
+            <p></p>
+          </Localized>
+          <button className="standalone" onClick={resetSkipped}>
+            <Localized id="sc-settings-show-all-button" />
+          </button>
+        </section>
       </section>
     </section>
   );

--- a/web/src/components/profile/settings.tsx
+++ b/web/src/components/profile/settings.tsx
@@ -9,7 +9,7 @@ import type { RootState } from '../../types';
 
 import LanguageSelector from '../language-selector';
 
-const CV_TRANSLATED_LOCALES = cvTranslatedLocales;
+const CV_TRANSLATED_LOCALES: string[] = cvTranslatedLocales;
 
 export default function Settings() {
   const { allLanguages = [], currentUILocale } = useSelector((state: RootState) => state.languages);

--- a/web/src/l10n.tsx
+++ b/web/src/l10n.tsx
@@ -5,12 +5,10 @@ import { negotiateLanguages } from '@fluent/langneg';
 import { FluentBundle, FluentResource } from '@fluent/bundle';
 import { ReactLocalization, LocalizationProvider } from '@fluent/react';
 
-import cvTranslatedLocales from '../../locales/translated.json';
 import cvRTLLocales from '../../locales/rtl.json';
 import type { RootState } from './types';
 
 export const DEFAULT_LOCALE = 'en';
-const AVAILABLE_LOCALES: string[] = cvTranslatedLocales;
 const RTL_LOCALES: string[] = cvRTLLocales;
 
 async function fetchMessages(locale: string): Promise<[string, string]> {
@@ -33,7 +31,7 @@ interface AppLocalizationProviderProps {
 }
 
 export function AppLocalizationProvider({ children }: AppLocalizationProviderProps) {
-  const { currentUILocale } = useSelector((state: RootState) => state.languages);
+  const { allLanguages = [], currentUILocale } = useSelector((state: RootState) => state.languages);
   const [currentLocales, setCurrentLocales] = useState([DEFAULT_LOCALE]);
   const [l10n, setL10n] = useState<ReactLocalization | null>(null);
 
@@ -43,7 +41,7 @@ export function AppLocalizationProvider({ children }: AppLocalizationProviderPro
       locales.unshift(currentUILocale);
     }
     changeLocales(locales);
-  }, [currentUILocale]);
+  }, [currentUILocale, allLanguages.length]);
 
   useEffect(() => {
     const mainLocale = currentLocales[0];
@@ -53,7 +51,8 @@ export function AppLocalizationProvider({ children }: AppLocalizationProviderPro
   }, [currentLocales]);
 
   async function changeLocales(userLocales: Array<string>) {
-    const negotiatedLocales = negotiateLanguages(userLocales, AVAILABLE_LOCALES, {
+    const allLanguageCodes = allLanguages.map((lang) => lang.id);
+    const negotiatedLocales = negotiateLanguages(userLocales, allLanguageCodes, {
       defaultLocale: DEFAULT_LOCALE,
     });
     setCurrentLocales(negotiatedLocales);


### PR DESCRIPTION
This adds a UI language selector to the profile. It will show *all* the languages for now. We can't reliably use `translated.json` as it really does not give much information on how much of Sentence Collector is actually translated. Therefore I went with that approach. However, if a locale is not in `translated.json` we show a warning with a link to Pontoon to help out with translation.

@HarikalarKutusu FYI for you. I will also write a more detailed localization update on Pontoon once all the recent changes are in production.