### PR TITLE
fix: link on logo in header reverts back UI to English

### DIFF
--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -66,7 +66,7 @@ export default function Header() {
   return (
     <React.Fragment>
       <header>
-        <Link to="/" href="">
+        <Link to={useLocaleUrl('/')} href="">
           <img src={logoURL} />
         </Link>
         <nav id="desktopNav">


### PR DESCRIPTION
Fix for https://github.com/common-voice/sentence-collector/issues/567