### PR TITLE
feat: add sentence validator for catalan

### DIFF
--- a/server/lib/validation/index.js
+++ b/server/lib/validation/index.js
@@ -13,6 +13,7 @@ const th = require('./languages/th');
 const ur = require('./languages/ur');
 const uz = require('./languages/uz');
 const yue = require('./languages/yue');
+const ca = require('./languages/ca');
 
 const VALIDATORS = {
   bas,
@@ -29,6 +30,7 @@ const VALIDATORS = {
   ur,
   uz,
   yue,
+  ca
 };
 
 module.exports = {

--- a/server/lib/validation/index.js
+++ b/server/lib/validation/index.js
@@ -1,5 +1,6 @@
 const defaultValidator = require('./languages/default');
 const bas = require('./languages/bas');
+const ca = require('./languages/ca');
 const ckb = require('./languages/ckb');
 const en = require('./languages/en');
 const eo = require('./languages/eo');
@@ -13,10 +14,10 @@ const th = require('./languages/th');
 const ur = require('./languages/ur');
 const uz = require('./languages/uz');
 const yue = require('./languages/yue');
-const ca = require('./languages/ca');
 
 const VALIDATORS = {
   bas,
+  ca,
   ckb,
   en,
   eo,
@@ -30,7 +31,6 @@ const VALIDATORS = {
   ur,
   uz,
   yue,
-  ca
 };
 
 module.exports = {

--- a/server/lib/validation/languages/ca.js
+++ b/server/lib/validation/languages/ca.js
@@ -1,12 +1,17 @@
-// According to Mozilla Italia guidelines, we count chars to validate instead of words.
-const MIN_LENGTH = 1;
-const MAX_LENGTH = 125;
+const tokenizeWords = require('talisman/tokenizers/words/gersam');
+
+// Minimum of words that qualify as a sentence.
+const MIN_WORDS = 1;
+
+// Maximum of words allowed per sentence to keep recordings in a manageable duration.
+const MAX_WORDS = 14;
 
 const INVALIDATIONS = [{
   fn: (sentence) => {
-    return sentence.length < MIN_LENGTH || sentence.length > MAX_LENGTH;
+    const words = tokenizeWords('ca', sentence);
+    return words.length < MIN_WORDS || words.length > MAX_WORDS;
   },
-  error: `Number of characters must be between ${MIN_LENGTH} and ${MAX_LENGTH} (inclusive)`,
+  error: `Number of words must be between ${MIN_WORDS} and ${MAX_WORDS} (inclusive)`,
 }, {
   regex: /[0-9]+/,
   error: 'Sentence should not contain numbers',
@@ -15,18 +20,16 @@ const INVALIDATIONS = [{
   regex: /[?!.].+/,
   error: 'Sentence should not contain sentence punctuation inside a sentence',
 }, {
-  // Italian: Simboli non permessi, aggiungere anche qui sotto oltre che nella regex:
-  // < > + * \ # @ ^ “ ” ‘ ’ ( ) É [ ] / { }
-  // doppio " " e più di un "." nella stessa frase.
-  regex: /[<>+*\\#@^“”‘’(){}É[\]/]|\s{2,}|!{2,}/,
+  // Symbols not allowed, also add them below as well to the regex:
+  // < > + * \ # @ ^ “ ” ‘ ’ ( ) [ ] / { }
+  regex: /[<>+*\\#@^“”‘’(){}[\]/]|\s{2,}|!{2,}/,
   error: 'Sentence should not contain symbols or multiple spaces/exclamation marks',
 }, {
   // Any words consisting of uppercase letters or uppercase letters with a period
   // inbetween are considered abbreviations or acronyms.
   // This currently also matches fooBAR but we most probably don't want that either
   // as users wouldn't know how to pronounce the uppercase letters.
-  // Versione italiana: dag7dev
-  regex: /[A-Z]{2,}|[A-Z][a-z]+\.*[A-Z]+/,
+  regex: /[A-Z]{2,}|[A-Z]+\.*[A-Z]+/,
   error: 'Sentence should not contain abbreviations',
 }];
 

--- a/server/lib/validation/languages/ca.js
+++ b/server/lib/validation/languages/ca.js
@@ -1,0 +1,35 @@
+// According to Mozilla Italia guidelines, we count chars to validate instead of words.
+const MIN_LENGTH = 1;
+const MAX_LENGTH = 125;
+
+const INVALIDATIONS = [{
+  fn: (sentence) => {
+    return sentence.length < MIN_LENGTH || sentence.length > MAX_LENGTH;
+  },
+  error: `Number of characters must be between ${MIN_LENGTH} and ${MAX_LENGTH} (inclusive)`,
+}, {
+  regex: /[0-9]+/,
+  error: 'Sentence should not contain numbers',
+}, {
+  // This could mean multiple sentences per line.
+  regex: /[?!.].+/,
+  error: 'Sentence should not contain sentence punctuation inside a sentence',
+}, {
+  // Italian: Simboli non permessi, aggiungere anche qui sotto oltre che nella regex:
+  // < > + * \ # @ ^ “ ” ‘ ’ ( ) É [ ] / { }
+  // doppio " " e più di un "." nella stessa frase.
+  regex: /[<>+*\\#@^“”‘’(){}É[\]/]|\s{2,}|!{2,}/,
+  error: 'Sentence should not contain symbols or multiple spaces/exclamation marks',
+}, {
+  // Any words consisting of uppercase letters or uppercase letters with a period
+  // inbetween are considered abbreviations or acronyms.
+  // This currently also matches fooBAR but we most probably don't want that either
+  // as users wouldn't know how to pronounce the uppercase letters.
+  // Versione italiana: dag7dev
+  regex: /[A-Z]{2,}|[A-Z][a-z]+\.*[A-Z]+/,
+  error: 'Sentence should not contain abbreviations',
+}];
+
+module.exports = {
+  INVALIDATIONS,
+};

--- a/server/lib/validation/languages/ca.js
+++ b/server/lib/validation/languages/ca.js
@@ -11,26 +11,26 @@ const INVALIDATIONS = [{
     const words = tokenizeWords('ca', sentence);
     return words.length < MIN_WORDS || words.length > MAX_WORDS;
   },
-  error: `Number of words must be between ${MIN_WORDS} and ${MAX_WORDS} (inclusive)`,
+  error: `El nombre de paraules ha de ser entre ${MIN_WORDS} i ${MAX_WORDS} (inclòs)`,
 }, {
   regex: /[0-9]+/,
-  error: 'Sentence should not contain numbers',
+  error: 'La frase no pot contenir nombres',
 }, {
   // This could mean multiple sentences per line.
   regex: /[?!.].+/,
-  error: 'Sentence should not contain sentence punctuation inside a sentence',
+  error: 'La frase no pot contenir signes de puntuació al mig',
 }, {
   // Symbols not allowed, also add them below as well to the regex:
   // < > + * \ # @ ^ “ ” ‘ ’ ( ) [ ] / { }
   regex: /[<>+*\\#@^“”‘’(){}[\]/]|\s{2,}|!{2,}/,
-  error: 'Sentence should not contain symbols or multiple spaces/exclamation marks',
+  error: 'La frase no pot contenir simbols o multiples espais o exclamacions',
 }, {
   // Any words consisting of uppercase letters or uppercase letters with a period
   // inbetween are considered abbreviations or acronyms.
   // This currently also matches fooBAR but we most probably don't want that either
   // as users wouldn't know how to pronounce the uppercase letters.
   regex: /[A-Z]{2,}|[A-Z]+\.*[A-Z]+/,
-  error: 'Sentence should not contain abbreviations',
+  error: 'La frase no pot contenir abreviacions o acrònims',
 }];
 
 module.exports = {


### PR DESCRIPTION
Uses the gersam tokenizer for Catalan that counts a word with a dash as a single word.