### PR TITLE
Create tok.js, update eo.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sentence-collector",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentence-collector",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "A web console for collecting and validating sentences",
   "repository": {
     "type": "git",

--- a/server/lib/validation/languages/eo.js
+++ b/server/lib/validation/languages/eo.js
@@ -11,20 +11,26 @@ const INVALIDATIONS = [{
     const words = tokenizeWords(sentence);
     return words.length < MIN_WORDS || words.length > MAX_WORDS;
   },
-  error: `Number of words must be between ${MIN_WORDS} and ${MAX_WORDS} (inclusive)`,
+  error: `Frazo devas havi minimume ${MIN_WORDS} kaj maksimume ${MAX_WORDS} vortojn`,
 }, {
+  // Sentence should not contain numbers
   regex: /[0-9]+/,
-  error: 'Sentence should not contain numbers',
+  error: 'Frazo devas ne enhavi numerojn',
 }, {
-  regex: /[<>+*#@^[\]()/wWqQxXyYäÄöÖüÜßððÀÁÂÃÅÆÇÈÉÊËÌÍİÎÏÐÑÒÓÔÕØÙÚÛÛÝŽàáâãåæçèéêëìíîïðñòóôõøùúûýþÿāăąćċčďđēĕėęěğġģħĩīĭįıķĸĺļľŀłńņņṫšЎḃḋḟṁṗṡẁẃẅẛỳαβΓγΔδεζηΘθικΛλμνΞξΠπρΣσςτșếōůūŁşşǐżőňựňžịŌŏČŠřś]/,
-  error: 'Sentence should not contain symbols, the letterss W, Q, X or Y or any letter that is not part of the EO alphabet',
+  // Sentence should not contain symbols
+  regex: /[<>+*#@^[\]()/]/,
+  error: 'Frazo devas ne enhavi specialajn signojn',
+}, {
+  // Sentence should not contain the letters W, Q, X, Y, or other letters that are not in the Esperanto alphabet
+  regex: /[qQwWxXyYÀ-ćĊ-ěĞ-ģĞ-ģĦ-ĳĶ-śŞ-ūŮ-\u02AF\u1E00-\u1EFFα-ωΑ-ΩЀ-ӿ]/,
+  error: 'Frazo devas ne enhavi la literojn W, Q, X, Y, aŭ aliajn ne-esperantajn literojn',
 }, {
   // Any words consisting of uppercase letters or uppercase letters with a period
   // inbetween are considered abbreviations or acronyms.
   // This currently also matches fooBAR but we most probably don't want that either
   // as users wouldn't know how to pronounce the uppercase letters.
   regex: /[A-Z]{2,}|[A-Z]+\.*[A-Z]+/,
-  error: 'Sentence should not contain abbreviations',
+  error: 'Frazo devas ne enhavi mallongigojn',
 }];
 
 module.exports = {

--- a/server/lib/validation/languages/tok.js
+++ b/server/lib/validation/languages/tok.js
@@ -1,7 +1,5 @@
 const tokenizeWords = require('talisman/tokenizers/words');
 
-const TRANSLATION_KEY_PREFIX = 'TRANSLATION_KEY:';
-
 // Minimum of words that qualify as a sentence.
 const MIN_WORDS = 1;
 
@@ -13,13 +11,13 @@ const INVALIDATIONS = [{
     const words = tokenizeWords(sentence);
     return words.length < MIN_WORDS || words.length > MAX_WORDS;
   },
-  error: `${TRANSLATION_KEY_PREFIX}sc-validation-number-of-words`,
+  error: `toki ni li ken jo e nimi pi mute ni taso: ${MIN_WORDS}-${MAX_WORDS}`,
 }, {
   regex: /[0-9]+/,
-  error: `${TRANSLATION_KEY_PREFIX}sc-validation-no-numbers`,
+  error: 'nanpa o lon ala toki ni',
 }, {
   regex: /[<>+*#@%^[\]()/]/,
-  error: `${TRANSLATION_KEY_PREFIX}sc-validation-no-symbols`,
+  error: 'sitelen nasa o lon ala toki ni',
 }, {
   // capital letters at start of word only
   regex: /[\w\.][A-Z]/,
@@ -31,8 +29,8 @@ const INVALIDATIONS = [{
 // pronunciations, and some speakers might struggle pronouncing them.
 
 {
-  // No non-Toki-Pona letters
-  regex: /[BbCcDdFfGgHhQqRrVvXxYyZzĈĜĤĴŜŬĉĝĥĵŝŭäÄöÖüÜßððÀÁÂÃÅÆÇÈÉÊËÌÍİÎÏÐÑÒÓÔÕØÙÚÛÛÝŽàáâãåæçèéêëìíîïðñòóôõøùúûýþÿāăąćċčďđēĕėęěğġģħĩīĭįıķĸĺļľŀłńņņṫšЎḃḋḟṁṗṡẁẃẅẛỳαβΓγΔδεζηΘθικΛλμνΞξΠπρΣσςτșếōůūŁşşǐżőňựňžịŌŏČŠřś]/,
+  // No non-Toki-Pona letters; no Sitelen Pona
+  regex: /[BbCcDdFfGgHhQqRrVvXxYyZz\u00C0-\u02BF\u1E00-\u1EFF\uF1900-\uF19FF]/,
   error: 'o kepeken sitelen Lasina pi toki pona taso',
 }, {
   // No consecutive vowels

--- a/server/lib/validation/languages/tok.js
+++ b/server/lib/validation/languages/tok.js
@@ -29,7 +29,7 @@ const INVALIDATIONS = [{
 // pronunciations, and some speakers might struggle pronouncing them.
 
 {
-  // No non-Toki-Pona letters; no Sitelen Pona
+  // No non-Toki-Pona letters; no Sitelen Pona (\uF1900-\uF19FF are UCSUR codepoints as of 2022)
   regex: /[BbCcDdFfGgHhQqRrVvXxYyZz\u00C0-\u02BF\u1E00-\u1EFF\uF1900-\uF19FF]/,
   error: 'o kepeken sitelen Lasina pi toki pona taso',
 }, {

--- a/server/lib/validation/languages/tok.js
+++ b/server/lib/validation/languages/tok.js
@@ -14,8 +14,8 @@ const INVALIDATIONS = [{
   regex: /[<>+*#@%^[\]()/]/,
   error: 'sitelen nasa o lon ala toki ni',
 }, {
-  // capital letters at start of word only
-  regex: /[\w\.][A-Z]/,
+  // capital letters at start of word only; no abbreviations
+  regex: /\w[A-Z]|[A-Z]\.[A-Z]/,
   error: 'sitelen suli li ken lon open nimi taso (ike: "jan AwiPota"; pona: "jan Awipota", "jan Awi Pota")',
 },
 
@@ -53,7 +53,7 @@ const INVALIDATIONS = [{
   error: 'sitelen "n" li lon open nimi la sitelen "j k l m p s t w" li ken ala sitelen nanpa tu',
 }, {
   // No invalid syllables
-  regex: /(Wu|wu|Wo|wo|Ji|ji|Ti|ti)/,
+  regex: /Wu|wu|Wo|wo|Ji|ji|Ti|ti/,
   error: 'sitelen "wu wo ji ti" li ken ala',
 }];
 

--- a/server/lib/validation/languages/tok.js
+++ b/server/lib/validation/languages/tok.js
@@ -1,17 +1,12 @@
-const tokenizeWords = require('talisman/tokenizers/words');
-
-// Minimum of words that qualify as a sentence.
-const MIN_WORDS = 1;
-
-// Maximum of words allowed per sentence to keep recordings in a manageable duration.
-const MAX_WORDS = 18;
+// Amount of characters allowed per sentence to keep recordings in a manageable duration.
+const MIN_LENGTH = 1;
+const MAX_LENGTH = 90;
 
 const INVALIDATIONS = [{
   fn: (sentence) => {
-    const words = tokenizeWords(sentence);
-    return words.length < MIN_WORDS || words.length > MAX_WORDS;
+    return sentence.length < MIN_LENGTH || sentence.length > MAX_LENGTH;
   },
-  error: `toki ni li ken jo e nimi pi mute ni taso: ${MIN_WORDS}-${MAX_WORDS}`,
+  error: `toki sitelen ni li suli ike, li ken jo e sitelen lili pi mute ni taso: ${MIN_LENGTH}-${MAX_LENGTH}`,
 }, {
   regex: /[0-9]+/,
   error: 'nanpa o lon ala toki ni',

--- a/server/lib/validation/languages/tok.js
+++ b/server/lib/validation/languages/tok.js
@@ -1,0 +1,70 @@
+const tokenizeWords = require('talisman/tokenizers/words');
+
+const TRANSLATION_KEY_PREFIX = 'TRANSLATION_KEY:';
+
+// Minimum of words that qualify as a sentence.
+const MIN_WORDS = 1;
+
+// Maximum of words allowed per sentence to keep recordings in a manageable duration.
+const MAX_WORDS = 18;
+
+const INVALIDATIONS = [{
+  fn: (sentence) => {
+    const words = tokenizeWords(sentence);
+    return words.length < MIN_WORDS || words.length > MAX_WORDS;
+  },
+  error: `${TRANSLATION_KEY_PREFIX}sc-validation-number-of-words`,
+}, {
+  regex: /[0-9]+/,
+  error: `${TRANSLATION_KEY_PREFIX}sc-validation-no-numbers`,
+}, {
+  regex: /[<>+*#@%^[\]()/]/,
+  error: `${TRANSLATION_KEY_PREFIX}sc-validation-no-symbols`,
+}, {
+  // capital letters at start of word only
+  regex: /[\w\.][A-Z]/,
+  error: 'sitelen suli li ken lon open nimi taso (ike: "jan AwiPota"; pona: "jan Awipota", "jan Awi Pota")',
+},
+
+// The following invalidations are to make all submissions conform to Toki Pona's
+// phonotactics. Any words that don't follow the phonotactics would have ambiguous
+// pronunciations, and some speakers might struggle pronouncing them.
+
+{
+  // No non-Toki-Pona letters
+  regex: /[BbCcDdFfGgHhQqRrVvXxYyZzĈĜĤĴŜŬĉĝĥĵŝŭäÄöÖüÜßððÀÁÂÃÅÆÇÈÉÊËÌÍİÎÏÐÑÒÓÔÕØÙÚÛÛÝŽàáâãåæçèéêëìíîïðñòóôõøùúûýþÿāăąćċčďđēĕėęěğġģħĩīĭįıķĸĺļľŀłńņņṫšЎḃḋḟṁṗṡẁẃẅẛỳαβΓγΔδεζηΘθικΛλμνΞξΠπρΣσςτșếōůūŁşşǐżőňựňžịŌŏČŠřś]/,
+  error: 'o kepeken sitelen Lasina pi toki pona taso',
+}, {
+  // No consecutive vowels
+  regex: /[AaEeIiOoUu]{2,}/,
+  error: 'sitelen "a e i o u" tu li ken ala lon poka',
+}, {
+  // No consecutive consonants (excluding N)
+  regex: /[JjKkLlMmPpSsTtWw]{2,}/,
+  error: 'sitelen "j k l m p s t w" tu li ken ala lon poka',
+}, {
+  // No word-final consonants other than N
+  regex: /[JjKkLlMmPpSsTtWw]\b/,
+  error: 'sitelen "j k l m p s t w" li ken ala lon pini nimi',
+}, {
+  // No N preceded by a consonant
+  regex: /[JjKkLlMmPpSsTtWw]n/,
+  error: 'sitelen "j k l m p s t w" li ken ala lon poka open pi sitelen "n"',
+}, {
+  // No "nn" or "nm"
+  regex: /[Nn][mn]/,
+  error: 'sitelen "nn" en sitelen "nm" li ken ala',
+}, {
+  // No word-initial "n + consonant" sequences
+  regex: /\b[Nn][jklmpstw]/,
+  error: 'sitelen "n" li lon open nimi la sitelen "j k l m p s t w" li ken ala sitelen nanpa tu',
+}, {
+  // No invalid syllables
+  regex: /(Wu|wu|Wo|wo|Ji|ji|Ti|ti)/,
+  error: 'sitelen "wu wo ji ti" li ken ala',
+}];
+
+
+module.exports = {
+  INVALIDATIONS,
+};


### PR DESCRIPTION
Wrote a new validation script for Toki Pona.

Changes compared to default:
- changed sentence limit from 14 words to 90 characters
- added rules to enforce Toki Pona's phonotactics, which should eliminate words and names with ambiguous or impossible pronunciations, and also catch a lot of typos
- added "capital letters at start of word only" rule, which can replace the default "no abbreviations" one

Also updated Esperanto's validation script with translations and minor improvements.