### PR TITLE
Fix to eo.js and tok.js validation scripts

### DIFF
--- a/server/lib/validation/languages/eo.js
+++ b/server/lib/validation/languages/eo.js
@@ -22,7 +22,7 @@ const INVALIDATIONS = [{
   error: 'Frazo devas ne enhavi specialajn signojn',
 }, {
   // Sentence should not contain the letters W, Q, X, Y, or other letters that are not in the Esperanto alphabet
-  regex: /[qQwWxXyYÀ-ćĊ-ěĞ-ģĞ-ģĦ-ĳĶ-śŞ-ūŮ-\u02AF\u1E00-\u1EFFα-ωΑ-ΩЀ-ӿ]/,
+  regex: /[qQwWxXyYÀ-ćĊ-ěĞ-ģĞ-ģĦ-ĳĶ-śŞ-ūŮ-ʯḀ-ỿα-ωΑ-ΩЀ-ӿ]/,
   error: 'Frazo devas ne enhavi la literojn W, Q, X, Y, aŭ aliajn ne-esperantajn literojn',
 }, {
   // Any words consisting of uppercase letters or uppercase letters with a period

--- a/server/lib/validation/languages/tok.js
+++ b/server/lib/validation/languages/tok.js
@@ -24,8 +24,8 @@ const INVALIDATIONS = [{
 // pronunciations, and some speakers might struggle pronouncing them.
 
 {
-  // No non-Toki-Pona letters; no Sitelen Pona (\uF1900-\uF19FF are UCSUR codepoints as of 2022)
-  regex: /[BbCcDdFfGgHhQqRrVvXxYyZz\u00C0-\u02BF\u1E00-\u1EFF\uF1900-\uF19FF]/,
+  // No non-Toki-Pona letters
+  regex: /[BbCcDdFfGgHhQqRrVvXxYyZzÀ-ʯḀ-ỿ]/,
   error: 'o kepeken sitelen Lasina pi toki pona taso',
 }, {
   // No consecutive vowels


### PR DESCRIPTION
Somehow `[BbCcDdFfGgHhQqRrVvXxYyZz\u00C0-\u02BF\u1E00-\u1EFF\uF1900-\uF19FF]` and `[qQwWxXyYÀ-ćĊ-ěĞ-ģĞ-ģĦ-ĳĶ-śŞ-ūŮ-\u02AF\u1E00-\u1EFFα-ωΑ-ΩЀ-ӿ]` match with all regular Latin letters as well, making the Sentence Collector reject all submissions.

Changed to `[BbCcDdFfGgHhQqRrVvXxYyZzÀ-ʯḀ-ỿ]` and `[qQwWxXyYÀ-ćĊ-ěĞ-ģĞ-ģĦ-ĳĶ-śŞ-ūŮ-ʯḀ-ỿα-ωΑ-ΩЀ-ӿ]`, which should work well. (At least they do in Notepad++, which I found has the same behavior.)