### PR TITLE
fix: stop persisting loading state

### DIFF
--- a/web/src/reducers/index.ts
+++ b/web/src/reducers/index.ts
@@ -18,7 +18,7 @@ const languagesPersistConfig = {
 const sentencesPersistConfig = {
   key: 'sentences',
   storage,
-  blacklist: ['sentences'],
+  blacklist: ['isUploadingSentences', 'sentences', 'sentencesLoading'],
 };
 
 export default function (history: History) {


### PR DESCRIPTION
In order to simulate the issue reported by #609 I added some artificial delay in the `/review` endpoint of the server and while the web app was trying to fetch the sentences I just had to change pages or refresh your browser. This will make the app stuck in the loading state.

As mentioned by @MichaelKohler, the easy solution is to not persist the loading state `sentencesLoading`.

The key `isUploadingSentences` is also a loading state, but I was not able to simulate any issues like above because it goes to the catch and the state goes back to `false`. I also added it in the exception list just for consistency sake, but I can remove if you all think it is better since it is not causing real problems for now.

I didn't add any tests since it this case would be better tested by some type of integration test, but doesn't look like we are using them in the repo, right?